### PR TITLE
Reduced 096's spawn frequency.

### DIFF
--- a/173blitz3D.ipf
+++ b/173blitz3D.ipf
@@ -18,6 +18,7 @@
  AbsPath="\Dreamfilter.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
  AbsPath="\FastExt.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
  AbsPath="\Items.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
+ AbsPath="\KeyName.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
  AbsPath="\Main.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
  AbsPath="\Map Creator\MapCreator.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"
  AbsPath="\MapSystem.bb" PrjFolder="" Line="0" Column="0" Tip="0" Visible="False"

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -29,6 +29,7 @@ v1.3.2
 - SCP-079 no longer opens the door to Dr. L.’s office if the remote door control system is turned off.
 - Fixed Security Chief Franklin using the default scientist texture during the office event if the intro sequence was enabled.
 - Disabled camera fog at Gate A and B.
+- Fixed a bug that cause SCP-096 to spawn too frequently.
 
 ----------------------------------------------------------------------------------
 

--- a/NPCs.bb
+++ b/NPCs.bb
@@ -809,7 +809,7 @@ Function UpdateNPCs()
 														DeathMSG = "Subject D-9341. Cause of death: Fatal cervical fracture. The surveillance tapes confirm that the subject was killed by SCP-173."	
 													Case "173"
 														If Rand(2)=1 Then
-															DeathMSG = Chr(34)+"Yes, we we're just about to start the tests when it started. The Class Ds and the guard died as soon as the lights started flickering, "
+															DeathMSG = Chr(34)+"Yes, we were just about to start the tests when it started. The Class Ds and the guard died as soon as the lights started flickering, "
 															DeathMSG = DeathMSG + "but I managed to get out of the surveillance room before it got me."+Chr(34)
 														Else
 															DeathMSG = "Subject D-9341. Cause of death: Fatal cervical fracture. According to Security Chief Franklin who was present at SCP-173's containment "
@@ -1223,7 +1223,7 @@ Function UpdateNPCs()
 									n\SoundChn2 = PlaySound_Strict (n\Sound2)
 								Else
 									If (Not ChannelPlaying(n\SoundChn2)) Then n\SoundChn2 = PlaySound_Strict(n\Sound2)
-									ChannelVolume(n\SoundChn2, Min(Max(8.0-dist,0.6),1.0))
+									ChannelVolume(n\SoundChn2, Min(Max(8.0-dist,0.6),1.0)*SFXVolume#)
 								EndIf
 							EndIf
 						EndIf
@@ -3881,7 +3881,7 @@ Function UpdateNPCs()
 									Msg="You can feel something near you, but you are unable to see it. Perhaps its time is now."
 							End Select
                             n\Reload = 20*70
-							MsgTimer=5*70
+							MsgTimer=8*70
 						EndIf
 						n\Reload = n\Reload - FPSfactor
 						

--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -8986,7 +8986,7 @@ Function UpdateEvents()
 					;[Block]
 					If e\EventState <> 2
 						If Curr096<>Null
-							If EntityDistance(Curr096\Collider,Collider)<HideDistance
+							If EntityDistance(Curr096\Collider,Collider)<45
 								e\EventState = 2
 								DebugLog "Failed to spawn SCP-096 in room "+e\room\RoomTemplate\Name$
 								DebugLog "- SCP-096 too close to player"
@@ -8998,6 +8998,17 @@ Function UpdateEvents()
 										e\EventState = 2
 										DebugLog "Failed to spawn SCP-096 in room "+e\room\RoomTemplate\Name$
 										DebugLog "- room2servers event still in progress"
+										Exit
+									EndIf
+								EndIf
+							Next
+							
+							For r.Rooms = Each Rooms
+   								If r\RoomTemplate\Name = "checkpoint1"
+									If r\dist < 10
+										e\EventState = 2
+										DebugLog "Failed to spawn SCP-096 in room "+e\room\RoomTemplate\Name$
+										DebugLog "- too close to checkpoint1"
 										Exit
 									EndIf
 								EndIf
@@ -9069,6 +9080,14 @@ Function UpdateEvents()
 						RotateEntity Curr096\Collider,0,EntityYaw(Curr096\Collider)+180,0
 						FreeEntity pvt%
 						Curr096\State = 5
+
+						;Play 096's ambience when spawned.
+						If Curr096\Sound2 = 0 Then
+							Curr096\Sound2 = LoadSound_Strict("SFX\096_1.ogg")
+						Else
+							Curr096\SoundChn2 = LoopSound2(Curr096\Sound2, Curr096\SoundChn2, Camera, Curr096\Collider, 16.0, 1.0)
+						EndIf
+
 						DebugLog "SCP-096 successfully placed in "+Chr(34)+e\room\RoomTemplate\Name+Chr(34)
 						e\EventState = 1
 					ElseIf e\EventState = 1
@@ -9087,7 +9106,7 @@ Function UpdateEvents()
 					EndIf
 				Else
 					If e\EventState = 2
-						If Rand(1,3-(1*SelectedDifficulty\aggressiveNPCs))
+						If Rand(-1,1+(2*SelectedDifficulty\aggressiveNPCs))>0 Then
 							e\EventState = 0
 						Else
 							e\EventState = 3


### PR DESCRIPTION
-Made it so he’s unable to spawn within a little over a room of the first checkpoint.
-Increased the eligibility of him spawning to roughly 5 rooms between previous 096 spawns.
-Attached 096_1.ogg to him, audible within 2 rooms of its spawn.
-Fixed a bug with its RNG, causing it to always spawn when eligible.

Also added KeyName.bb to the IDEal project file. (not sure if that does anything but I noticed it was missing from it)