### PR TITLE
Fit resolutions up to 1920x1080 in launcher window

### DIFF
--- a/Menu.bb
+++ b/Menu.bb
@@ -1098,7 +1098,7 @@ Function UpdateLauncher()
 		Text(20, 240 - 65, "Resolution: ")
 		
 		Local x% = 40
-		Local y% = 280 - 65
+		Local y% = 270 - 65
 		For i = 0 To (GFXModes - 1)
 			Color 0, 0, 0
 			If SelectedGFXMode = i Then Rect(x - 1, y - 1, 100, 20, False)
@@ -1111,7 +1111,7 @@ Function UpdateLauncher()
 			EndIf
 			
 			y=y+20
-			If y >= 240 - 65 + (LauncherHeight - 80 - 260) Then y = 280 - 65 : x=x+100
+			If y >= 250 - 65 + (LauncherHeight - 80 - 260) Then y = 270 - 65 : x=x+100
 		Next
 		
 		;-----------------------------------------------------------------


### PR DESCRIPTION
Increased number of resolution options drawn per column in launcher by
1, and re-centered appropriately, so that 1680x1050 and 1920x1080
options no longer spill over onto other graphics options