### PR TITLE
Fixed floating buttons in room2closets and options not saving when esc is pressed.

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,7 @@
 - Added a vomit parameter to SCP-294.
 - New battery textures (by Cridone).
 - Leaving the name field blank when creating a new game now sets the game name to "untitled".
+- The options menu is now saved when the "esc" key is pressed to unpause the game.
 
 Bug Fixes:
 - Fixed collsion issues with structures in SCP-1499's dimension.
@@ -15,6 +16,7 @@ Bug Fixes:
 - Fixed the gas mask in room2closets having a reduced size.
 - Fixed the maintenance tunnels not generating based on the selected seed.
 - Fixed a button in room2shaft being placed inside a wall.
+- Fixed the floating buttons in room2closets.
 
 ----------------------------------------------------------------------------------
 

--- a/Items.bb
+++ b/Items.bb
@@ -792,6 +792,13 @@ Function Update294()
 	CatchErrors("Update294")
 End Function
 
+
+
+
+
+
+
+
 ;~IDEal Editor Parameters:
 ;~F#B#1E
 ;~C#Blitz3D

--- a/MapSystem.bb
+++ b/MapSystem.bb
@@ -689,26 +689,20 @@ Function LoadRMesh(file$,rt.RoomTemplates)
 			Case "model"
 				file = ReadString(f)
 				If file<>""
-					;Local model = CreatePropObj("GFX\Map\Props\"+file);LoadMesh("GFX\Map\Props\"+file)
-					;
-					;temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
-					;PositionEntity model,temp1,temp2,temp3
-					;
-					;temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
-					;RotateEntity model,temp1,temp2,temp3
-					;
-					;temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
-					;ScaleEntity model,temp1,temp2,temp3
-					;
-					;EntityParent model,Opaque
-					;EntityType model,HIT_MAP
-					;EntityPickMode model,2
-					Local tmpr.TempMapProps = New TempMapProps
-					tmpr\file = file
-					tmpr\x=ReadFloat(f)*RoomScale : tmpr\y=ReadFloat(f)*RoomScale : tmpr\z=ReadFloat(f)*RoomScale
-					tmpr\pitch=ReadFloat(f) : tmpr\yaw=ReadFloat(f) : tmpr\roll=ReadFloat(f)
-					tmpr\scaleX=ReadFloat(f)*RoomScale : tmpr\scaleY=ReadFloat(f)*RoomScale : tmpr\scaleZ=ReadFloat(f)*RoomScale
-					tmpr\rt = rt
+					Local model = CreatePropObj("GFX\Map\Props\"+file);LoadMesh("GFX\Map\Props\"+file)
+					
+					temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
+					PositionEntity model,temp1,temp2,temp3
+					
+					temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
+					RotateEntity model,temp1,temp2,temp3
+					
+					temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
+					ScaleEntity model,temp1,temp2,temp3
+					
+					EntityParent model,Opaque
+					EntityType model,HIT_MAP
+					EntityPickMode model,2
 				Else
 					DebugLog "file = 0"
 					temp1=ReadFloat(f) : temp2=ReadFloat(f) : temp3=ReadFloat(f)
@@ -2369,7 +2363,8 @@ Function FillRoom(r.Rooms)
 		Case "room2shaft"
 			;[Block]
 			d = CreateDoor(r\zone, r\x + 1552.0 * RoomScale, r\y, r\z + 552.0 * RoomScale, 0, r, False, False)
-			PositionEntity(d\buttons[0], EntityX(d\buttons[0],True), EntityY(d\buttons[0],True), r\z + 512.0 * RoomScale,True)
+			PositionEntity(d\buttons[0], EntityX(d\buttons[0],True), EntityY(d\buttons[0],True), r\z + 518.0 * RoomScale, True)
+			PositionEntity(d\buttons[1], EntityX(d\buttons[1],True), EntityY(d\buttons[1],True), r\z + 575.0 * RoomScale, True)
 			d\AutoClose = False : d\open = False
 			
 			d = CreateDoor(r\zone, r\x + 256.0 * RoomScale, r\y, r\z + 744.0 * RoomScale, 90, r, False, False, 2)
@@ -3360,9 +3355,9 @@ Function FillRoom(r.Rooms)
 			PositionEntity r\Objects[1], r\x-1232*RoomScale, -256*RoomScale, r\z-160*RoomScale, True
 			
 			d.Doors = CreateDoor(0, r\x - 240.0 * RoomScale, 0.0, r\z, 90, r, False)
-			d\open = False : d\AutoClose = False 
-			MoveEntity(d\buttons[0], 0.0, 0.0, 22.0 * RoomScale)
-			MoveEntity(d\buttons[1], 0.0, 0.0, 22.0 * RoomScale)
+			PositionEntity(d\buttons[0], r\x - 230.0 * RoomScale, EntityY(d\buttons[0],True), EntityZ(d\buttons[0],True), True)
+			PositionEntity(d\buttons[1], r\x - 250.0 * RoomScale, EntityY(d\buttons[1],True), EntityZ(d\buttons[1],True), True)
+			d\open = False : d\AutoClose = False
 			
 			sc.SecurityCams = CreateSecurityCam(r\x, r\y + 704*RoomScale, r\z + 863*RoomScale, r)
 			sc\angle = 180
@@ -4919,20 +4914,6 @@ Function FillRoom(r.Rooms)
 			
 			r\SoundEmitter[i] = r\RoomTemplate\TempSoundEmitter[i]
 			r\SoundEmitterRange[i] = r\RoomTemplate\TempSoundEmitterRange[i]
-		EndIf
-	Next
-	
-	For tmpr.TempMapProps = Each TempMapProps
-		If tmpr\rt = r\RoomTemplate
-			mpr.MapProps = New MapProps
-			mpr\obj% = CreatePropObj("GFX\Map\Props\"+tmpr\file)
-			PositionEntity mpr\obj%,r\x+tmpr\x,r\y+tmpr\y,r\z+tmpr\z
-			RotateEntity mpr\obj%,tmpr\pitch,tmpr\yaw,tmpr\roll
-			ScaleEntity mpr\obj%,tmpr\scaleX,tmpr\scaleY,tmpr\scaleZ
-			EntityParent mpr\obj%,r\obj
-			EntityType mpr\obj%,HIT_MAP
-			EntityPickMode mpr\obj%,2
-			DebugLog "Created prop: "+tmpr\file+"|"+mpr\obj
 		EndIf
 	Next
 	
@@ -7830,36 +7811,13 @@ Function FindAndDeleteFakeMonitor(r.Rooms,x#,y#,z#,Amount%)
 	
 End Function
 
-Type TempMapProps
-	Field rt.RoomTemplates
-	Field x#,y#,z#
-	Field pitch#,yaw#,roll#
-	Field scaleX#,scaleY#,scaleZ#
-	Field file$
-End Type
 
-Type MapProps
-	Field obj%
-End Type
 
-Function UpdateMapProps()
-	Local mpr.MapProps
-	
-	For mpr.MapProps = Each MapProps
-		If mpr\obj<>0
-			If EntityDistance(mpr\obj,Camera)>8.0
-				HideEntity mpr\obj
-			Else
-				ShowEntity mpr\obj
-			EndIf
-		EndIf
-	Next
-End Function
 
 
 
 
 ;~IDEal Editor Parameters:
 ;~F#2#A
-;~B#1230
+;~B#122B
 ;~C#Blitz3D

--- a/Menu.bb
+++ b/Menu.bb
@@ -225,41 +225,7 @@ Function UpdateMainMenu()
 					PutINIValue(OptionFile, "options", "intro enabled", IntroEnabled%)
 					MainMenuTab = 0
 				Case 3,5,6,7 ;save the options
-					PutINIValue(OptionFile, "options", "mouse sensitivity", MouseSens)
-					PutINIValue(OptionFile, "options", "invert mouse y", InvertMouse)
-					PutINIValue(OptionFile, "options", "bump mapping enabled", BumpEnabled)			
-					PutINIValue(OptionFile, "options", "HUD enabled", HUDenabled)
-					PutINIValue(OptionFile, "options", "screengamma", ScreenGamma)
-					PutINIValue(OptionFile, "options", "antialias", Opt_AntiAlias)
-					PutINIValue(OptionFile, "options", "vsync", Vsync)
-					PutINIValue(OptionFile, "options", "show FPS", ShowFPS)
-					PutINIValue(OptionFile, "options", "framelimit", Framelimit%)
-					PutINIValue(OptionFile, "options", "achievement popup enabled", AchvMSGenabled%)
-					PutINIValue(OptionFile, "options", "room lights enabled", EnableRoomLights%)
-					PutINIValue(OptionFile, "options", "texture details", TextureDetails%)
-					PutINIValue(OptionFile, "console", "enabled", CanOpenConsole%)
-					PutINIValue(OptionFile, "console", "auto opening", ConsoleOpening%)
-					PutINIValue(OptionFile, "options", "antialiased text", AATextEnable)
-					PutINIValue(OptionFile, "options", "res details",ResolutionDetails)
-					PutINIValue(OptionFile, "options", "particle amount",ParticleAmount)
-					PutINIValue(OptionFile, "options", "prop fading",PropFading)
-					
-					PutINIValue(OptionFile, "audio", "music volume", MusicVolume)
-					PutINIValue(OptionFile, "audio", "sound volume", PrevSFXVolume)
-					PutINIValue(OptionFile, "audio", "sfx release", EnableSFXRelease)
-					PutINIValue(OptionFile, "audio", "enable user tracks", EnableUserTracks%)
-					PutINIValue(OptionFile, "audio", "user track setting", UserTrackMode%)
-					
-					PutINIValue(OptionFile, "binds", "Right key", KEY_RIGHT)
-					PutINIValue(OptionFile, "binds", "Left key", KEY_LEFT)
-					PutINIValue(OptionFile, "binds", "Up key", KEY_UP)
-					PutINIValue(OptionFile, "binds", "Down key", KEY_DOWN)
-					PutINIValue(OptionFile, "binds", "Blink key", KEY_BLINK)
-					PutINIValue(OptionFile, "binds", "Sprint key", KEY_SPRINT)
-					PutINIValue(OptionFile, "binds", "Inventory key", KEY_INV)
-					PutINIValue(OptionFile, "binds", "Crouch key", KEY_CROUCH)
-					PutINIValue(OptionFile, "binds", "Save key", KEY_SAVE)
-					PutINIValue(OptionFile, "binds", "Console key", KEY_CONSOLE)
+					SaveOptionsINI()
 					
 					UserTrackCheck% = 0
 					UserTrackCheck2% = 0
@@ -481,8 +447,8 @@ Function UpdateMainMenu()
 					Next
 					
 					If SaveMSG <> ""
-						x = GraphicWidth / 2
-						y = GraphicHeight / 2
+						x = 740 * MenuScale
+						y = 376 * MenuScale
 						DrawFrame(x, y, 420 * MenuScale, 200 * MenuScale)
 						RowText("Are you sure you want to delete this save?", x + 20 * MenuScale, y + 15 * MenuScale, 400 * MenuScale, 200 * MenuScale)
 						;AAText(x + 20 * MenuScale, y + 15 * MenuScale, "Are you sure you want to delete this save?")
@@ -681,14 +647,6 @@ Function UpdateMainMenu()
 						DrawOptionsTooltip(tx,ty,tw,th+100*MenuScale,"texquality")
 					EndIf
 					
-;					y=y+50*MenuScale
-;					
-;						Color 255,255,255
-;					AAText(x + 20 * MenuScale, y, "Enable prop fading:")
-;					PropFading = DrawTick(x + 310 * MenuScale, y + MenuScale, PropFading)
-;					If MouseOn(x+310*MenuScale,y+MenuScale,20*MenuScale,20*MenuScale) And OnSliderID=0
-;						DrawOptionsTooltip(tx,ty,tw,th+100*MenuScale,"propfading")
-;					EndIf
 					;[End Block]
 				ElseIf MainMenuTab = 5 ;Audio
 					;[Block]
@@ -1930,8 +1888,6 @@ Function DrawOptionsTooltip(x%,y%,width%,height%,option$,value#=0,ingame%=False)
 					G = 255
 					txt2 = "All particles are rendered."
 			End Select
-		Case "propfading"
-			txt = "Hides props in the world when the player gets too far from them."
 			;[End Block]
 		;Sound options
 			;[Block]

--- a/options.ini
+++ b/options.ini
@@ -30,7 +30,6 @@ texture details = 3
 antialiased text = 0
 res details = 2
 particle amount = 2
-prop fading = 1
 check for updates = false
 
 [audio]


### PR DESCRIPTION
- Fixed the floating buttons in room2closets.
- Repositioned the buttons in room2shaft slightly.
- Options are now saved when esc is pressed.
- Several props seemed to misplaced throughout the game with the "prop fading" code, and given that it appears to no longer be in use anymore, I reverted it back to the original system.
- Moved the set of PutINIValue() calls for the options into a SaveOptionsINI() function. That way the code only needs to be modified in one place for it to take effect on both the main menu and pause menu.