### PR TITLE
Fix non-facility rooms contributing to "rooms found"

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -3786,8 +3786,11 @@ Function DrawEnding()
 					
 					Local roomamount = 0, roomsfound = 0
 					For r.Rooms = Each Rooms
-						roomamount = roomamount + 1
-						roomsfound = roomsfound + r\found
+						Local RN$ = r\RoomTemplate\Name$
+						If RN$ <> "dimension1499" And RN$ <> "gatea" And RN$ <> "pocketdimension" Then 
+							roomamount = roomamount + 1
+							roomsfound = roomsfound + r\found
+						EndIf
 					Next
 					
 					Local docamount=0, docsfound=0


### PR DESCRIPTION
"dimension1499" and "gatea" do not get marked as found when they are entered so it is likely that non-facility rooms were never intended to contribute to "rooms found" in the first place
Fixed by ChronoQuote