### PR TITLE
Fixed wrong array for saving the levers

### DIFF
--- a/Save.bb
+++ b/Save.bb
@@ -755,7 +755,7 @@ Function LoadGame(file$)
 			EndIf
 		Next
 		
-		For x=0 To 11
+		For x=0 To 10
 			id = ReadByte(f)
 			If id=2 Then
 				Exit
@@ -1583,7 +1583,7 @@ Function LoadGameQuick(file$)
 			EndIf
 		Next
 		
-		For x=0 To 11
+		For x=0 To 10
 			id = ReadByte(f)
 			If id=2 Then
 				Exit


### PR DESCRIPTION
The array is getting out of bounds, because we have "Field Levers%[11]" (from 0 to 10)