### PR TITLE
Fixed an ability to select items without any function

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -7026,15 +7026,12 @@ Function DrawGUI()
 				Default
 					;[Block]
 					;check if the item is an inventory-type object
-					If SelectedItem\invSlots>0 Then
-						DoubleClick = 0
-						MouseHit1 = 0
-						MouseDown1 = 0
-						LastMouseHit1 = 0
-						OtherOpen = SelectedItem
-						SelectedItem = Null
-					EndIf
-					
+					DoubleClick = 0
+					MouseHit1 = 0
+					MouseDown1 = 0
+					LastMouseHit1 = 0
+					If SelectedItem\invSlots>0 Then OtherOpen = SelectedItem
+					SelectedItem = Null
 					;[End Block]
 			End Select
 			


### PR DESCRIPTION
For example, we can select a battery, but the battery doesn't have any functions. After clicling mouse 2 we can hear an unselect sound