### PR TITLE
Fixes to room2closets clipboard+document

### DIFF
--- a/MapSystem.bb
+++ b/MapSystem.bb
@@ -3822,11 +3822,15 @@ Function FillRoom(r.Rooms)
 			it = CreateItem("Level 1 Key Card", "key1", r\x + 736.0 * RoomScale, r\y + 240.0 * RoomScale, r\z + 752.0 * RoomScale)
 			EntityParent(it\collider, r\obj)
 			
-			Local clipboard.Items = CreateItem("Clipboard","clipboard",r\x + 736.0 * RoomScale, r\y + 224.0 * RoomScale, r\z -480.0 * RoomScale)
-			EntityParent(it\collider, r\obj)
+			Local clipboard.Items = CreateItem("Clipboard","clipboard",r\x + 736.0 * RoomScale, r\y + 224.0 * RoomScale, r\z -720.0 * RoomScale)
+			EntityParent(clipboard\collider, r\obj)
 			
-			it = CreateItem("Incident Report SCP-1048-A", "paper",r\x + 736.0 * RoomScale, r\y + 224.0 * RoomScale, r\z -480.0 * RoomScale)
-			;clipboard\SecondInv[0] = it
+			it = CreateItem("Incident Report SCP-1048-A", "paper",r\x + 736.0 * RoomScale, r\y + 224.0 * RoomScale, r\z -720.0 * RoomScale)
+			it\Picked = True
+			it\Dropped = -1
+			clipboard\SecondInv[0] = it
+			SetAnimTime clipboard\model, 0.0
+			clipboard\invimg = clipboard\itemtemplate\invimg
 			HideEntity(it\collider)
 			
 			r\Objects[0]=CreatePivot(r\obj)


### PR DESCRIPTION
-Fixed clipboard and document not receiving correct EntityParent calls which meant they were not rotated along with the room object whenever the room got placed, resulting in the items being in any of four different spots depending on the room's rotation
-Attached the document to the clipboard as originally intended
-Moved clipboard one shelf to the right of the intended shelf as it was getting bumped around by the batteries on the shelf below

Before:
![Fixes to room2closets clipboard+document (before 1)](https://user-images.githubusercontent.com/94698137/185899819-d0750c9e-2a9a-4251-8d36-417c8c3684b3.png)
![Fixes to room2closets clipboard+document (before 2)](https://user-images.githubusercontent.com/94698137/185899838-a460354a-796f-46fd-b4ff-fb2c2d2ed7cf.png)

After:
![Fixes to room2closets clipboard+document (after)](https://user-images.githubusercontent.com/94698137/185899849-b526a27b-4000-4643-a186-983aa7ef0af0.png)