### PR TITLE
Fixes and improvements for SCP-049 removing SCP-714/Hazmat Suit

### DIFF
--- a/Save.bb
+++ b/Save.bb
@@ -1261,6 +1261,7 @@ Function LoadGame(file$)
 	EndIf
 	
 	UpdateDoorsTimer = 0
+	TakeOffTimer = 0
 	
 	CatchErrors("LoadGame")
 End Function
@@ -1990,6 +1991,8 @@ Function LoadGameQuick(file$)
 	;Resetting some stuff (those get changed when going to the endings)
 	CameraFogMode(Camera, 1)
 	HideDistance# = 15.0
+	
+	TakeOffTimer = 0
 	
 	CatchErrors("LoadGameQuick")
 End Function


### PR DESCRIPTION
- Made a new variable called "TakeOffTimer" instead of "BlurTimer" leading to premature death in cases where the player already had the "BlurTimer" parameter;
- If you are wearing both SCP-714 and the hazmat suit, SCP-049 now removes both instead of just the hazmat suit;
- Added messages and unequip SFX to make it clearer to the player what SCP-049 does to SCP-714 and the Hazmat Suit;
- Make removal voice lines play sooner, replacing the initial awkward silence on contact and ensuring SCP-049 is able to play the "kidnap" voice lines when killing player;
- Fixed removal voice lines being spammable by repeatedly approaching and backing away from SCP-049;
- Removed unnecessary PrevState assignments;
- Fixed by ChronoQuote and Jabka