### PR TITLE
Fix for player kidnapping animation

### DIFF
--- a/NPCs.bb
+++ b/NPCs.bb
@@ -1784,7 +1784,7 @@ Function UpdateNPCs()
 													Next
 												Else
 													DeathMSG = "An active instance of SCP-049-2 was discovered in [REDACTED]. Terminated by Nine-Tailed Fox."
-													Kill()
+													Kill() : KillAnim = 0
 												EndIf
 												PlaySound_Strict HorrorSFX(13)
 												If n\Sound2 <> 0 Then FreeSound_Strict(n\Sound2)


### PR DESCRIPTION
I'm not sure if this is a bug, but I think it make sense
After kidnapping the player, the ``Kill`` function plays a random animation, so we don't see SCP-049 animation
Before:
![image](https://user-images.githubusercontent.com/41839972/185906511-8e0b85fd-289f-4efd-9a35-fffa6a66475b.png)
After:
![image](https://user-images.githubusercontent.com/41839972/185906294-7e2cd4ff-1dd2-46a7-8601-00b221041424.png)
