### PR TITLE
Fix saves ending in (2) being overwritten instead of creating a (3)

### DIFF
--- a/Menu.bb
+++ b/Menu.bb
@@ -387,10 +387,13 @@ Function UpdateMainMenu()
 					
 					SeedRnd GenerateSeedNumber(RandomSeed)
 					
-					Local SameFound% = False
+					Local SameFound% = 0
 					
-					For  i% = 1 To SaveGameAmount
-						If SaveGames(i - 1) = CurrSave Then SameFound = SameFound + 1
+					For i% = 1 To SaveGameAmount
+						If (SameFound = 0 And SaveGames(i - 1) = CurrSave) Or (SameFound > 0 And SaveGames(i - 1) = CurrSave + " (" + (SameFound + 1) + ")") Then
+							SameFound = SameFound + 1
+							i = 0
+						EndIf
 					Next
 						
 					If SameFound > 0 Then CurrSave = CurrSave + " (" + (SameFound + 1) + ")"


### PR DESCRIPTION
When you start a new save with the name of a save that already exists, the game generously appends a (2) to the name of the new save so as not to overwrite the old one. Unfortunately the generosity stops there as the game will overwrite the save ending in (2) if the player starts a third new save with that name.

See commit for details.