### PR TITLE
Fix DrawTiledImageRect

### DIFF
--- a/Menu.bb
+++ b/Menu.bb
@@ -1319,11 +1319,10 @@ Function DrawTiledImageRect(img%, srcX%, srcY%, srcwidth#, srcheight#, x%, y%, w
 	
 	Local x2% = x
 	While x2 < x+width
+		If x2 + srcwidth > x + width Then srcwidth = (x + width) - x2
 		Local y2% = y
 		While y2 < y+height
-			If x2 + srcwidth > x + width Then srcwidth = srcwidth - Max((x2 + srcwidth) - (x + width), 1)
-			If y2 + srcheight > y + height Then srcheight = srcheight - Max((y2 + srcheight) - (y + height), 1)
-			DrawImageRect(img, x2, y2, srcX, srcY, srcwidth, srcheight)
+			DrawImageRect(img, x2, y2, srcX, srcY, srcwidth, Min((y + height) - y2, srcheight))
 			y2 = y2 + srcheight
 		Wend
 		x2 = x2 + srcwidth


### PR DESCRIPTION
`DrawTiledImageRect` takes a patch from an image and tiles a rectangle with copies of that patch. It starts in the top left corner and moves down. When a patch eventually surpasses the bottom of the rectangle, the patch is snipped to fit, then the function moves to the next column. The problem is that the original patch is what got snipped, not the copy. This means all future copies of the patch are shorter, and continue to get shorter the further to the right the function progresses, resulting in a very strange image. The problem is more apparent the longer the rectangle is.

The solution is to only snip the copy by passing the adjusted `srcheight` value to `DrawImageRect` directly rather than modifying `srcheight`. It's okay to modify `srcwidth` as we won't need any more columns after reaching the right end of the rectangle. We only need to modify it once though, so the line has been moved outside the y-loop. Some expressions have also been simplified.

Before:
![Fix DrawTiledImageRect (before 1)](https://user-images.githubusercontent.com/94698137/186895798-0175c457-5eb5-4f76-9103-0f3a7cf4ccee.png)
![Fix DrawTiledImageRect (before 2)](https://user-images.githubusercontent.com/94698137/186895809-e21e105f-f63e-4a81-abe9-323795cb60df.png)

After:
![Fix DrawTiledImageRect (after 1)](https://user-images.githubusercontent.com/94698137/186895840-7c29be5a-1001-442a-92c6-073e4c684db0.png)
![Fix DrawTiledImageRect (after 2)](https://user-images.githubusercontent.com/94698137/186895852-f93d94a6-5210-4a5c-8e28-dca53ddea47d.png)