### PR TITLE
Fixed unexisting "CurrMusicStream" variable

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -1590,7 +1590,7 @@ Music(25) = "SaveMeFrom"
 Global MusicVolume# = GetINIFloat(OptionFile, "audio", "music volume")
 ;Global MusicCHN% = StreamSound_Strict("SFX\Music\"+Music(2)+".ogg", MusicVolume, CurrMusicStream)
 
-Global CurrMusicStream, MusicCHN
+Global MusicCHN
 MusicCHN = StreamSound_Strict("SFX\Music\"+Music(2)+".ogg",MusicVolume,Mode)
 
 Global CurrMusicVolume# = 1.0, NowPlaying%=2, ShouldPlay%=11

--- a/Menu.bb
+++ b/Menu.bb
@@ -208,7 +208,7 @@ Function UpdateMainMenu()
 						;FMOD_CloseStream(CurrMusicStream)
 						;FMOD_Close()
 						;FMOD_StopStream(CurrMusicStream)
-						FSOUND_Stream_Stop(CurrMusicStream)
+						StopStream_Strict(MusicCHN)
 						;FSOUND_Close()
 						End
 					EndIf


### PR DESCRIPTION
- Replaced unexisting ``CurrMusicStream`` variable by ``MusicCHN``. Is this line really necessary?