### PR TITLE
Fixes to 294 and 294 drinks

### DIFF
--- a/Data/SCP-294.ini
+++ b/Data/SCP-294.ini
@@ -1,24 +1,28 @@
 ;color = the color of the liquid
-;alpha = the transparency of the liquid (0.0 = invisible, 1.0 = nontransparent)
-;glow = makes the liquid glow (true/false)
+;alpha = the transparency of the liquid (0.0 = invisible, 1.0 = opaque)
+;glow = true/false, makes the liquid glow
 
 ;sound = the sound clip played when the player drinks the liquid
-;dispensesound = the sound clip played when the liquid is dispensed ("SFX\SCP\294\dispense1.ogg" by default). 
+;dispensesound = the sound clip played when the liquid is dispensed ("SFX\SCP\294\dispense1.ogg" by default)
 
-;lethal = true/false
-;deathmessage = the text shown in the game over -screen if the player dies when drinking the liquid
+;message = text shown on the screen after drinking the liquid
+;refusemessage = text shown on the screen after refusing to drink the liquid (must exist for the player to refuse to drink it)
+
+;lethal = true/false, kills the player immediately after drinking the liquid
+;deathtimer = (if not lethal) how many seconds before killing the player after drinking the liquid
+;explosion = true/false, creates an explosion similar to the one at Gate B when the liquid is dispensed
+;deathmessage = the text shown in the game over screen if the liquid kills the player
 
 ;blur = how many seconds the screen stays blurry after drinking the liquid
-;message = a text shown on the screen after drinking the liquid
-;damage = increases the injuries-value
-;blood loss = increases the blood loss - value
+;vomit = how many seconds the player feels sick after drinking the liquid, before vomiting
+;camerashake = how many seconds the camera shakes after drinking the liquid
+;damage = increases the injuries value
+;blood loss = increases the blood loss value
 ;stomachache = true/false, has the same effect as appendicitis caused by SCP-1025 (decreased stamina and messages about stomach ache)
 
 ;stamina effect = changes how fast stamina decreases (1.0 = normal speed, 2.0 = decreases twice as fast, 0.0 = doesn't decrease at all)
-;stamina effect timer = the amount of time it takes before stamina effect wears off
+;stamina effect timer = how many seconds before stamina effect wears off
 ;blink effect, blink effect timer
-
-;explosion = true/false, creates an explosion similar to the one at Gate B
 
 [Air|Nothing|Cup|Emptiness|Vacuum|HL3|Half Life 3]
 color = 0,0,0

--- a/Items.bb
+++ b/Items.bb
@@ -394,6 +394,8 @@ Function CreateItem.Items(name$, tempname$, x#, y#, z#, r%=0,g%=0,b%=0,a#=1.0,in
 	i\DropSpeed = 0.0
 	
 	If tempname = "cup" Then
+		i\state = 1.0
+		
 		i\r=r
 		i\g=g
 		i\b=b

--- a/Items.bb
+++ b/Items.bb
@@ -800,7 +800,7 @@ Function Update294()
 	CatchErrors("Uncaught (Update294)")
 	
 	If CameraShakeTimer > 0 Then
-		CameraShakeTimer = CameraShakeTimer - (FPSfactor/70)
+		CameraShakeTimer = Max(CameraShakeTimer - (FPSfactor/70), 0)
 		CameraShake = 2
 	EndIf
 	

--- a/Main.bb
+++ b/Main.bb
@@ -6034,6 +6034,9 @@ Function DrawGUI()
 						
 						;Stop
 						
+						strtemp = GetINIString2(iniStr, loc, "sound")
+						If strtemp <> "" Then PlaySound_Strict LoadTempSound(strtemp)
+						
 						strtemp = GetINIString2(iniStr, loc, "message")
 						If strtemp <> "" Then Msg = strtemp : MsgTimer = 70*6
 						
@@ -6041,26 +6044,32 @@ Function DrawGUI()
 							DeathMSG = GetINIString2(iniStr, loc, "deathmessage")
 							If GetINIInt2(iniStr, loc, "lethal") Then Kill()
 						EndIf
-						BlurTimer = Max(BlurTimer + GetINIInt2(iniStr, loc, "blur")*70, 0);*temp
-						If VomitTimer = 0 Then
-							VomitTimer = GetINIInt2(iniStr, loc, "vomit")
-						Else
-							VomitTimer = Min(VomitTimer, GetINIInt2(iniStr, loc, "vomit"))
-						EndIf
-						CameraShakeTimer = Max(CameraShakeTimer + GetINIString2(iniStr, loc, "camerashake"), 0)
-						Injuries = Max(Injuries + GetINIInt2(iniStr, loc, "damage"),0);*temp
-						Bloodloss = Max(Bloodloss + GetINIInt2(iniStr, loc, "blood loss"),0);*temp
-						strtemp = GetINIString2(iniStr, loc, "sound")
-						If strtemp <> "" Then
-							PlaySound_Strict LoadTempSound(strtemp)
-						EndIf
-						If GetINIInt2(iniStr, loc, "stomachache") Then SCP1025state[3]=1
 						
-						If DeathTimer = 0 Then
-							DeathTimer = GetINIInt2(iniStr, loc, "deathtimer")*70
-						Else
-							DeathTimer = Min(DeathTimer, GetINIInt2(iniStr, loc, "deathtimer")*70)
+						BlurTimer = Max(BlurTimer + GetINIInt2(iniStr, loc, "blur")*70, 0);*temp
+						CameraShakeTimer = Max(CameraShakeTimer + GetINIString2(iniStr, loc, "camerashake"), 0)
+						
+						temp = GetINIInt2(iniStr, loc, "vomit")*70
+						If temp > 0 Then
+							If VomitTimer = 0 Then
+								VomitTimer = temp
+							Else
+								VomitTimer = Min(VomitTimer, temp)
+							EndIf
 						EndIf
+						
+						temp = GetINIInt2(iniStr, loc, "deathtimer")*70
+						If temp > 0 Then
+							If DeathTimer = 0 Then
+								DeathTimer = temp
+							Else
+								DeathTimer = Min(DeathTimer, temp)
+							EndIf
+						EndIf
+						
+						Injuries = Max(Injuries + GetINIInt2(iniStr, loc, "damage"), 0);*temp
+						Bloodloss = Max(Bloodloss + GetINIInt2(iniStr, loc, "blood loss"), 0);*temp
+						
+						If GetINIInt2(iniStr, loc, "stomachache") Then SCP1025state[3]=1
 						
 						;the state of refined drinks is more than 1.0 (fine setting increases it by 1, very fine doubles it)
 						strtemp = GetINIString2(iniStr, loc, "blink effect")

--- a/Main.bb
+++ b/Main.bb
@@ -6021,16 +6021,16 @@ Function DrawGUI()
 				Case "cup"
 					;[Block]
 					If CanUseItem(False,False,True)
-						SelectedItem\name = Trim(Lower(SelectedItem\name))
-						If Left(SelectedItem\name, Min(6,Len(SelectedItem\name))) = "cup of" Then
-							SelectedItem\name = Right(SelectedItem\name, Len(SelectedItem\name)-7)
-						ElseIf Left(SelectedItem\name, Min(8,Len(SelectedItem\name))) = "a cup of" 
-							SelectedItem\name = Right(SelectedItem\name, Len(SelectedItem\name)-9)
+						strtemp = Trim(Lower(SelectedItem\name))
+						If Left(strtemp, 6) = "cup of" Then
+							strtemp = Right(strtemp, Len(strtemp)-7)
+						ElseIf Left(strtemp, 8) = "a cup of"
+							strtemp = Right(strtemp, Len(strtemp)-9)
 						EndIf
 						
 						Local iniStr$ = "DATA\SCP-294.ini"
 						
-						Local loc% = GetINISectionLocation(iniStr, SelectedItem\name)
+						Local loc% = GetINISectionLocation(iniStr, strtemp)
 						
 						;Stop
 						
@@ -6041,24 +6041,36 @@ Function DrawGUI()
 							DeathMSG = GetINIString2(iniStr, loc, "deathmessage")
 							If GetINIInt2(iniStr, loc, "lethal") Then Kill()
 						EndIf
-						BlurTimer = GetINIInt2(iniStr, loc, "blur")*70;*temp
-						If VomitTimer = 0 Then VomitTimer = GetINIInt2(iniStr, loc, "vomit")
-						CameraShakeTimer = GetINIString2(iniStr, loc, "camerashake")
+						BlurTimer = Max(BlurTimer + GetINIInt2(iniStr, loc, "blur")*70, 0);*temp
+						If VomitTimer = 0 Then
+							VomitTimer = GetINIInt2(iniStr, loc, "vomit")
+						Else
+							VomitTimer = Min(VomitTimer, GetINIInt2(iniStr, loc, "vomit"))
+						EndIf
+						CameraShakeTimer = Max(CameraShakeTimer + GetINIString2(iniStr, loc, "camerashake"), 0)
 						Injuries = Max(Injuries + GetINIInt2(iniStr, loc, "damage"),0);*temp
 						Bloodloss = Max(Bloodloss + GetINIInt2(iniStr, loc, "blood loss"),0);*temp
-						strtemp =  GetINIString2(iniStr, loc, "sound")
-						If strtemp<>"" Then
+						strtemp = GetINIString2(iniStr, loc, "sound")
+						If strtemp <> "" Then
 							PlaySound_Strict LoadTempSound(strtemp)
 						EndIf
 						If GetINIInt2(iniStr, loc, "stomachache") Then SCP1025state[3]=1
 						
-						DeathTimer=GetINIInt2(iniStr, loc, "deathtimer")*70
+						If DeathTimer = 0 Then
+							DeathTimer = GetINIInt2(iniStr, loc, "deathtimer")*70
+						Else
+							DeathTimer = Min(DeathTimer, GetINIInt2(iniStr, loc, "deathtimer")*70)
+						EndIf
 						
 						;the state of refined drinks is more than 1.0 (fine setting increases it by 1, very fine doubles it)
-						BlinkEffect = Float(GetINIString2(iniStr, loc, "blink effect", 1.0))^SelectedItem\state
-						BlinkEffectTimer = Float(GetINIString2(iniStr, loc, "blink effect timer", 1.0))*SelectedItem\state
-						StaminaEffect = Float(GetINIString2(iniStr, loc, "stamina effect", 1.0))^SelectedItem\state
-						StaminaEffectTimer = Float(GetINIString2(iniStr, loc, "stamina effect timer", 1.0))*SelectedItem\state
+						strtemp = GetINIString2(iniStr, loc, "blink effect")
+						If strtemp <> "" Then BlinkEffect = Float(strtemp)^SelectedItem\state
+						strtemp = GetINIString2(iniStr, loc, "blink effect timer")
+						If strtemp <> "" Then BlinkEffectTimer = Float(strtemp)*SelectedItem\state
+						strtemp = GetINIString2(iniStr, loc, "stamina effect")
+						If strtemp <> "" Then StaminaEffect = Float(strtemp)^SelectedItem\state
+						strtemp = GetINIString2(iniStr, loc, "stamina effect timer")
+						If strtemp <> "" Then StaminaEffectTimer = Float(strtemp)*SelectedItem\state
 						
 						strtemp = GetINIString2(iniStr, loc, "refusemessage")
 						If strtemp <> "" Then

--- a/Main.bb
+++ b/Main.bb
@@ -6028,9 +6028,6 @@ Function DrawGUI()
 							SelectedItem\name = Right(SelectedItem\name, Len(SelectedItem\name)-9)
 						EndIf
 						
-						;the state of refined items is more than 1.0 (fine setting increases it by 1, very fine doubles it)
-						x2 = (SelectedItem\state+1.0)
-						
 						Local iniStr$ = "DATA\SCP-294.ini"
 						
 						Local loc% = GetINISectionLocation(iniStr, SelectedItem\name)
@@ -6057,11 +6054,11 @@ Function DrawGUI()
 						
 						DeathTimer=GetINIInt2(iniStr, loc, "deathtimer")*70
 						
-						BlinkEffect = Float(GetINIString2(iniStr, loc, "blink effect", 1.0))*x2
-						BlinkEffectTimer = Float(GetINIString2(iniStr, loc, "blink effect timer", 1.0))*x2
-						
-						StaminaEffect = Float(GetINIString2(iniStr, loc, "stamina effect", 1.0))*x2
-						StaminaEffectTimer = Float(GetINIString2(iniStr, loc, "stamina effect timer", 1.0))*x2
+						;the state of refined drinks is more than 1.0 (fine setting increases it by 1, very fine doubles it)
+						BlinkEffect = Float(GetINIString2(iniStr, loc, "blink effect", 1.0))^SelectedItem\state
+						BlinkEffectTimer = Float(GetINIString2(iniStr, loc, "blink effect timer", 1.0))*SelectedItem\state
+						StaminaEffect = Float(GetINIString2(iniStr, loc, "stamina effect", 1.0))^SelectedItem\state
+						StaminaEffectTimer = Float(GetINIString2(iniStr, loc, "stamina effect timer", 1.0))*SelectedItem\state
 						
 						strtemp = GetINIString2(iniStr, loc, "refusemessage")
 						If strtemp <> "" Then
@@ -10013,25 +10010,17 @@ Function Use914(item.Items, setting$, x#, y#, z#)
 							d.Decals = CreateDecal(0, x, 8 * RoomScale + 0.010, z, 90, Rand(360), 0)
 							d\Size = 0.2 : EntityAlpha(d\obj, 0.8) : ScaleSprite(d\obj, d\Size, d\Size)
 						Case "1:1"
-							it2 = CreateItem("cup", "cup", x,y,z)
+							it2 = CreateItem("cup", "cup", x,y,z, 255-item\r,255-item\g,255-item\b,item\a)
 							it2\name = item\name
-							it2\r = 255-item\r
-							it2\g = 255-item\g
-							it2\b = 255-item\b
+							it2\state = item\state
 						Case "fine"
-							it2 = CreateItem("cup", "cup", x,y,z)
+							it2 = CreateItem("cup", "cup", x,y,z, Min(item\r*Rnd(0.9,1.1),255),Min(item\g*Rnd(0.9,1.1),255),Min(item\b*Rnd(0.9,1.1),255),item\a)
 							it2\name = item\name
-							it2\state = 1.0
-							it2\r = Min(item\r*Rnd(0.9,1.1),255)
-							it2\g = Min(item\g*Rnd(0.9,1.1),255)
-							it2\b = Min(item\b*Rnd(0.9,1.1),255)
+							it2\state = item\state+1.0
 						Case "very fine"
-							it2 = CreateItem("cup", "cup", x,y,z)
+							it2 = CreateItem("cup", "cup", x,y,z, Min(item\r*Rnd(0.5,1.5),255),Min(item\g*Rnd(0.5,1.5),255),Min(item\b*Rnd(0.5,1.5),255),item\a)
 							it2\name = item\name
-							it2\state = Max(it2\state*2.0,2.0)	
-							it2\r = Min(item\r*Rnd(0.5,1.5),255)
-							it2\g = Min(item\g*Rnd(0.5,1.5),255)
-							it2\b = Min(item\b*Rnd(0.5,1.5),255)
+							it2\state = item\state*2
 							If Rand(5)=1 Then
 								ExplosionTimer = 135
 							EndIf

--- a/Main.bb
+++ b/Main.bb
@@ -10075,7 +10075,7 @@ Function Use294()
 	temp = True
 	If PlayerRoom\SoundCHN<>0 Then temp = False
 	
-	AAText x+907, y+185, Input294, True,True
+	AAText x+905, y+185, Right(Input294,13), True,True
 	
 	If temp Then
 		If MouseHit1 Then
@@ -10169,8 +10169,6 @@ Function Use294()
 			EndIf
 			
 			Input294 = Input294 + strtemp
-			
-			Input294 = Left(Input294, Min(Len(Input294),15))
 			
 			If temp And Input294<>"" Then ;dispense
 				Input294 = Trim(Lower(Input294))
@@ -11044,12 +11042,13 @@ Function GetINISectionLocation%(file$, section$)
 		If Left(strtemp,1) = "[" Then
 			strtemp$ = Lower(strtemp)
 			Temp = Instr(strtemp, section)
-			If Temp>0 Then
-				If Mid(strtemp, Temp-1, 1)="[" Or Mid(strtemp, Temp-1, 1)="|" Then
+			While Temp>0
+				If (Mid(strtemp, Temp-1, 1)="[" Or Mid(strtemp, Temp-1, 1)="|") And (Mid(strtemp, Temp+Len(section), 1)="]" Or Mid(strtemp, Temp+Len(section), 1)="|") Then
 					CloseFile f
 					Return n
 				EndIf
-			EndIf
+				Temp = Instr(strtemp, section, Temp+Len(section)+1)
+			Wend
 		EndIf
 	Wend
 	


### PR DESCRIPTION
### e7ad23e17d82c96c8ae1fc24907e202d89b4898e Fixes to refining 294 drinks with 914
- Correctly pass RGBA values to CreateItem to fix refined drinks turning black and losing glow
- Give drinks an initial state of 1.0 so the state itself may act as the status effect multiplier rather than the variable x2 (which was just the state plus one); this improves readability for the following fix
- Fix status effect multipliers not being modified as intended after refinement; drinks on 1:1 now keep their multiplier, drinks on fine now have their multiplier increased by 1, and drinks on very fine now have their multiplier doubled
- Raise status effects to the power of the multiplier instead of multiplying them by it, so drinks that decrease a stamina/blink consumption rate decrease it even more after being refined, and drinks that increase a stamina/blink consumption rate increase it even more after being refined

### f305a9c2d9494acf188039a82cb932f6cd5cc80a Fixes to 294
- Improve GetINISectionLocation to fix sometimes getting the wrong drink (e.g. "Lifeforce" instead of "Life"); 294 now looks for the first full match in SCP-294.ini rather than the first partial match
- Remove input character limit to allow drinks with long names to be dispensed (and because the "real" 294 doesn't have a character limit); the display will now only show the rightmost 13 characters of the input
- Center the text on the display a little better

Before: https://streamable.com/bs4gb7

After: https://streamable.com/0i39o8

### 8a2ecab5534befb0ea1ec1e490365a5915bb9919 (+ c47690f120ac891bec2c9114a58248bcbbb9a3ee) Fixes to 294 drinks
- Store trimmed drink name in strtemp rather than replacing real drink name to fix drink names changing when the player refuses the drink
- Drinks no longer replace BlurTimer and CameraShakeTimer but instead add to them; this fixes a bug where even a cup of air could cure blurry vision
- Drinking a drink with a "deathtimer"/"vomit" value while you already have a positive but larger DeathTimer/VomitTimer value will now update the timer with the smaller value (e.g. if you drink a drink that kills you in 50 seconds then one that kills you in 10 seconds, you'll now die in 10 seconds instead of 50)
- Drinks now only replace BlinkEffect, BlinkEffectTimer, StaminaEffect, and StaminaEffectTimer if they were specified to; this fixes a bug where even a cup of air could cure blink and stamina debuffs

Before: https://streamable.com/l6vdcq

After: https://streamable.com/vz01ns

### 2afa019228cee2666ca89fb0d27cbb315ebc8b65 Improve SCP-294.ini comments
Clarified some descriptions and added missing ones.