### PR TITLE
Fixes to map generation

### DIFF
--- a/MapSystem.bb
+++ b/MapSystem.bb
@@ -8564,15 +8564,15 @@ Function CalculateRoomExtents(r.Rooms)
 	
 	;convert from the rooms local space to world space
 	TFormVector(r\RoomTemplate\MinX, r\RoomTemplate\MinY, r\RoomTemplate\MinZ, r\obj, 0)
-	r\MinX = TFormedX() + shrinkAmount + r\x
-	r\MinY = TFormedY() + shrinkAmount
-	r\MinZ = TFormedZ() + shrinkAmount + r\z
+	r\MinX = TFormedX() + r\x
+	r\MinY = TFormedY()
+	r\MinZ = TFormedZ() + r\z
 	
 	;convert from the rooms local space to world space
 	TFormVector(r\RoomTemplate\MaxX, r\RoomTemplate\MaxY, r\RoomTemplate\MaxZ, r\obj, 0)
-	r\MaxX = TFormedX() - shrinkAmount + r\x
-	r\MaxY = TFormedY() - shrinkAmount
-	r\MaxZ = TFormedZ() - shrinkAmount + r\z
+	r\MaxX = TFormedX() + r\x
+	r\MaxY = TFormedY()
+	r\MaxZ = TFormedZ() + r\z
 	
 	If (r\MinX > r\MaxX) Then
 		Local tempX# = r\MaxX
@@ -8584,6 +8584,10 @@ Function CalculateRoomExtents(r.Rooms)
 		r\MaxZ = r\MinZ
 		r\MinZ = tempZ
 	EndIf
+	
+	r\MinX = r\MinX + shrinkAmount : r\MaxX = r\MaxX - shrinkAmount
+	r\MinY = r\MinY + shrinkAmount : r\MaxY = r\MaxY - shrinkAmount
+	r\MinZ = r\MinZ + shrinkAmount : r\MaxZ = r\MaxZ - shrinkAmount
 	
 	DebugLog("roomextents: "+r\MinX+", "+r\MinY	+", "+r\MinZ	+", "+r\MaxX	+", "+r\MaxY+", "+r\MaxZ)
 End Function

--- a/MapSystem.bb
+++ b/MapSystem.bb
@@ -7273,14 +7273,14 @@ Function CreateMap()
 					If MapTemp(x,y)=1 Then
 						Select True ;see if adding some rooms is possible
 							Case MapTemp(x-1,y)>0
-								If (MapTemp(x,y-1)+MapTemp(x,y+1)+MapTemp(x+2,y))=0 Then
-									If (MapTemp(x+1,y-2)+MapTemp(x+2,y-1)+MapTemp(x+1,y-1))=0 Then
+								If (MapTemp(x+1,y-1)+MapTemp(x+1,y+1)+MapTemp(x+2,y))=0 Then
+									If (MapTemp(x+1,y-2)+MapTemp(x+2,y-1))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x+1,y)=2
 										DebugLog "ROOM2C forced into slot ("+(x+1)+", "+(y)+")"
 										MapTemp(x+1,y-1)=1
 										temp=1
-									Else If (MapTemp(x+1,y+2)+MapTemp(x+2,y+1)+MapTemp(x+1,y+1))=0 Then
+									Else If (MapTemp(x+1,y+2)+MapTemp(x+2,y+1))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x+1,y)=2
 										DebugLog "ROOM2C forced into slot ("+(x+1)+", "+(y)+")"
@@ -7289,14 +7289,14 @@ Function CreateMap()
 									EndIf
 								EndIf
 							Case MapTemp(x+1,y)>0
-								If (MapTemp(x,y-1)+MapTemp(x,y+1)+MapTemp(x-2,y))=0 Then
-									If (MapTemp(x-1,y-2)+MapTemp(x-2,y-1)+MapTemp(x-1,y-1))=0 Then
+								If (MapTemp(x-1,y-1)+MapTemp(x-1,y+1)+MapTemp(x-2,y))=0 Then
+									If (MapTemp(x-1,y-2)+MapTemp(x-2,y-1))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x-1,y)=2
 										DebugLog "ROOM2C forced into slot ("+(x-1)+", "+(y)+")"
 										MapTemp(x-1,y-1)=1
 										temp=1
-									Else If (MapTemp(x-1,y+2)+MapTemp(x-2,y+1)+MapTemp(x-1,y+1))=0 Then
+									Else If (MapTemp(x-1,y+2)+MapTemp(x-2,y+1))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x-1,y)=2
 										DebugLog "ROOM2C forced into slot ("+(x-1)+", "+(y)+")"
@@ -7305,14 +7305,14 @@ Function CreateMap()
 									EndIf
 								EndIf
 							Case MapTemp(x,y-1)>0
-								If (MapTemp(x-1,y)+MapTemp(x+1,y)+MapTemp(x,y+2))=0 Then
-									If (MapTemp(x-2,y+1)+MapTemp(x-1,y+2)+MapTemp(x-1,y+1))=0 Then
+								If (MapTemp(x-1,y+1)+MapTemp(x+1,y+1)+MapTemp(x,y+2))=0 Then
+									If (MapTemp(x-2,y+1)+MapTemp(x-1,y+2))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x,y+1)=2
 										DebugLog "ROOM2C forced into slot ("+(x)+", "+(y+1)+")"
 										MapTemp(x-1,y+1)=1
 										temp=1
-									Else If (MapTemp(x+2,y+1)+MapTemp(x+1,y+2)+MapTemp(x+1,y+1))=0 Then
+									Else If (MapTemp(x+2,y+1)+MapTemp(x+1,y+2))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x,y+1)=2
 										DebugLog "ROOM2C forced into slot ("+(x)+", "+(y+1)+")"
@@ -7321,14 +7321,14 @@ Function CreateMap()
 									EndIf
 								EndIf
 							Case MapTemp(x,y+1)>0
-								If (MapTemp(x-1,y)+MapTemp(x+1,y)+MapTemp(x,y-2))=0 Then
-									If (MapTemp(x-2,y-1)+MapTemp(x-1,y-2)+MapTemp(x-1,y-1))=0 Then
+								If (MapTemp(x-1,y-1)+MapTemp(x+1,y-1)+MapTemp(x,y-2))=0 Then
+									If (MapTemp(x-2,y-1)+MapTemp(x-1,y-2))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x,y-1)=2
 										DebugLog "ROOM2C forced into slot ("+(x)+", "+(y-1)+")"
 										MapTemp(x-1,y-1)=1
 										temp=1
-									Else If (MapTemp(x+2,y-1)+MapTemp(x+1,y-2)+MapTemp(x+1,y-1))=0 Then
+									Else If (MapTemp(x+2,y-1)+MapTemp(x+1,y-2))=0 Then
 										MapTemp(x,y)=2
 										MapTemp(x,y-1)=2
 										DebugLog "ROOM2C forced into slot ("+(x)+", "+(y-1)+")"


### PR DESCRIPTION
### 836ab8e6df72436ee55be20e2481adbf2c496791 Fix CalculateRoomExtents
shrinkAmount was applied before the potential min/max swap, resulting in room extents being larger than intended if the swap occurred. This fix resolves some instances of room overlap but not all.

### 6565fea09c37a7642edf7863fe91e6d8c9c27c06 Fix room2C forcing
After generating the facility layout, the game tries to force a room2C (corner tile) into each zone that doesn't have one. To do this, it finds a room1 (dead end tile) and checks whether there's space to extend it one tile forward then one tile sideways, forming an L shape. But it wasn't checking the correct spots to determine whether there's space, so sometimes the L would graze by another room1. Luckily, room shapes are recalculated when rooms are created, so the room2C would end up being a room3 (T-shaped tile) and the grazed room1 would end up being a room2 (hallway tile). However, room assignment still expected the additional room2C and room1, and so those tiles' room assignments got pushed to the next available room2C and room1, meaning not only that those rooms likely ended up in the wrong zone, but also that the very last room2C assignment (usually room2ccont, the electrical center, required to beat the game) and the very last room1 assignment (usually gateaentrance, required for two endings and for the MTF to spawn) never occurred.

I used a seed checker I created to check 10000 seeds before and after the fix. The fix reduced the ratio of unbeatable seeds from 5.28% to 3.72%. I hope to use this branch to reduce this ratio even further (without rewriting the whole map system).

Here's seed "n790" before the fix:
![image](https://user-images.githubusercontent.com/94698137/188430269-9db8f16f-3c15-4095-aa9e-fdf3b1960b00.png)

Notice that coffin and room2cpit, both HCZ rooms, are in EZ. Also notice that gateaentrance and room2ccont are missing. These problems were all caused by the forcing of a room2C just north of the room4 (four-way tile) in the center of the image.

Here's what that area looked like before the forcing:
![image](https://user-images.githubusercontent.com/94698137/188431429-67c1c3a6-a812-456c-9739-5ac5a7e1be54.png)

The room1 north of the room4 is selected as a candidate for extension into an L shape. To determine which way the room1 could be extended, the game checks these four spots:
![image](https://user-images.githubusercontent.com/94698137/188435460-86f1cc7c-7b3f-49c6-a7d6-4c14e832c5e2.png)

The southern spot is occupied, so the extension would be northward. To determine whether there's space, the game first checks these three spots:
![image](https://user-images.githubusercontent.com/94698137/188432631-73638223-5207-4b76-bdad-ecb6914fa621.png)

They're empty, so to determine whether there's space to extend east after extending north, the game checks these three spots:
![image](https://user-images.githubusercontent.com/94698137/188433219-3e409398-5fde-445c-afcd-85d32d11b0f8.png)

Some are occupied, so to determine whether there's space to instead extend west after extending north, the game checks these three spots:
![image](https://user-images.githubusercontent.com/94698137/188434007-20635233-0b87-4bef-9978-26e514f5c38e.png)

They're empty, so the extension is performed, resulting in what we see in the final image.

With the fix, after the extension direction is determined, these are the spots that get checked for forward extension:
![image](https://user-images.githubusercontent.com/94698137/188435851-b5739585-1248-404b-99d9-d780b1c6ccde.png)

And if they're empty, these are the spots that get checked for sideways extension:
![image](https://user-images.githubusercontent.com/94698137/188436100-6c34a758-49d3-4033-9e12-434021707317.png) ![image](https://user-images.githubusercontent.com/94698137/188436186-541caf48-2d82-4b01-b603-ace4ad65f9e9.png)

In this case, the forward extension check fails.

Here's what "n790" looks like after the fix:
![image](https://user-images.githubusercontent.com/94698137/188437183-14bbebbb-be78-43ef-b982-875ef60d23a1.png)

Much better!