### PR TITLE
Stream channels fix #2

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -948,9 +948,11 @@ Function UpdateConsole()
 					For n.NPCs = Each NPCs
 						If n\NPCtype = NPCtype096 Then
 							n\State = 0
-							StopStream_Strict(n\SoundChn) : n\SoundChn=0
+							If n\SoundChn<>0
+								StopStream_Strict(n\SoundChn) : n\SoundChn=0 : n\SoundChn_isStream = False
+							EndIf
 							If n\SoundChn2<>0
-								StopStream_Strict(n\SoundChn2) : n\SoundChn2=0
+								StopStream_Strict(n\SoundChn2) : n\SoundChn2=0 : n\SoundChn2_isStream = False
 							EndIf
 							Exit
 						EndIf
@@ -9064,14 +9066,14 @@ Function PauseSounds()
 	For e.events = Each Events
 		If e\soundchn <> 0 Then
 			If (Not e\soundchn_isstream)
-				If ChannelPlaying(e\soundchn) Then PauseChannel(e\soundchn)
+				PauseChannel(e\soundchn)
 			Else
 				SetStreamPaused_Strict(e\soundchn,True)
 			EndIf
 		EndIf
 		If e\soundchn2 <> 0 Then
 			If (Not e\soundchn2_isstream)
-				If ChannelPlaying(e\soundchn2) Then PauseChannel(e\soundchn2)
+				PauseChannel(e\soundchn2)
 			Else
 				SetStreamPaused_Strict(e\soundchn2,True)
 			EndIf
@@ -9081,42 +9083,46 @@ Function PauseSounds()
 	For n.npcs = Each NPCs
 		If n\soundchn <> 0 Then
 			If (Not n\soundchn_isstream)
-				If ChannelPlaying(n\soundchn) Then PauseChannel(n\soundchn)
+				PauseChannel(n\soundchn)
 			Else
-				If n\soundchn_isstream=True
-					SetStreamPaused_Strict(n\soundchn,True)
-				EndIf
+				SetStreamPaused_Strict(n\soundchn,True)
 			EndIf
 		EndIf
 		If n\soundchn2 <> 0 Then
 			If (Not n\soundchn2_isstream)
-				If ChannelPlaying(n\soundchn2) Then PauseChannel(n\soundchn2)
+				PauseChannel(n\soundchn2)
 			Else
-				If n\soundchn2_isstream=True
-					SetStreamPaused_Strict(n\soundchn2,True)
-				EndIf
+				SetStreamPaused_Strict(n\soundchn2,True)
 			EndIf
 		EndIf
 	Next	
 	
 	For d.doors = Each Doors
 		If d\soundchn <> 0 Then
-			If ChannelPlaying(d\soundchn) Then PauseChannel(d\soundchn)
+			PauseChannel(d\soundchn)
 		EndIf
 	Next
 	
 	For dem.DevilEmitters = Each DevilEmitters
 		If dem\soundchn <> 0 Then
-			If ChannelPlaying(dem\soundchn) Then PauseChannel(dem\soundchn)
+			PauseChannel(dem\soundchn)
 		EndIf
 	Next
 	
 	If AmbientSFXCHN <> 0 Then
-		If ChannelPlaying(AmbientSFXCHN) Then PauseChannel(AmbientSFXCHN)
+		PauseChannel(AmbientSFXCHN)
 	EndIf
 	
 	If BreathCHN <> 0 Then
-		If ChannelPlaying(BreathCHN) Then PauseChannel(BreathCHN)
+		PauseChannel(BreathCHN)
+	EndIf
+	
+	If CoughCHN <> 0 Then
+		PauseChannel(CoughCHN)
+	EndIf
+	
+	If VomitCHN <> 0 Then
+		PauseChannel(VomitCHN)
 	EndIf
 	
 	If IntercomStreamCHN <> 0
@@ -9128,14 +9134,14 @@ Function ResumeSounds()
 	For e.events = Each Events
 		If e\soundchn <> 0 Then
 			If (Not e\soundchn_isstream)
-				If ChannelPlaying(e\soundchn) Then ResumeChannel(e\soundchn)
+				ResumeChannel(e\soundchn)
 			Else
 				SetStreamPaused_Strict(e\soundchn,False)
 			EndIf
 		EndIf
 		If e\soundchn2 <> 0 Then
 			If (Not e\soundchn2_isstream)
-				If ChannelPlaying(e\soundchn2) Then ResumeChannel(e\soundchn2)
+				ResumeChannel(e\soundchn2)
 			Else
 				SetStreamPaused_Strict(e\soundchn2,False)
 			EndIf
@@ -9145,42 +9151,46 @@ Function ResumeSounds()
 	For n.npcs = Each NPCs
 		If n\soundchn <> 0 Then
 			If (Not n\soundchn_isstream)
-				If ChannelPlaying(n\soundchn) Then ResumeChannel(n\soundchn)
+				ResumeChannel(n\soundchn)
 			Else
-				If n\soundchn_isstream=True
-					SetStreamPaused_Strict(n\soundchn,False)
-				EndIf
+				SetStreamPaused_Strict(n\soundchn,False)
 			EndIf
 		EndIf
 		If n\soundchn2 <> 0 Then
 			If (Not n\soundchn2_isstream)
-				If ChannelPlaying(n\soundchn2) Then ResumeChannel(n\soundchn2)
+				ResumeChannel(n\soundchn2)
 			Else
-				If n\soundchn2_isstream=True
-					SetStreamPaused_Strict(n\soundchn2,False)
-				EndIf
+				SetStreamPaused_Strict(n\soundchn2,False)
 			EndIf
 		EndIf
 	Next	
 	
 	For d.doors = Each Doors
 		If d\soundchn <> 0 Then
-			If ChannelPlaying(d\soundchn) Then ResumeChannel(d\soundchn)
+			ResumeChannel(d\soundchn)
 		EndIf
 	Next
 	
 	For dem.DevilEmitters = Each DevilEmitters
 		If dem\soundchn <> 0 Then
-			If ChannelPlaying(dem\soundchn) Then ResumeChannel(dem\soundchn)
+			ResumeChannel(dem\soundchn)
 		EndIf
 	Next
 	
 	If AmbientSFXCHN <> 0 Then
-		If ChannelPlaying(AmbientSFXCHN) Then ResumeChannel(AmbientSFXCHN)
+		ResumeChannel(AmbientSFXCHN)
 	EndIf	
 	
 	If BreathCHN <> 0 Then
-		If ChannelPlaying(BreathCHN) Then ResumeChannel(BreathCHN)
+		ResumeChannel(BreathCHN)
+	EndIf
+	
+	If CoughCHN <> 0 Then
+		ResumeChannel(CoughCHN)
+	EndIf
+	
+	If VomitCHN <> 0 Then
+		ResumeChannel(VomitCHN)
 	EndIf
 	
 	If IntercomStreamCHN <> 0
@@ -9197,54 +9207,68 @@ Function KillSounds()
 	For e.Events = Each Events
 		If e\SoundCHN <> 0 Then
 			If (Not e\SoundCHN_isStream)
-				If ChannelPlaying(e\SoundCHN) Then StopChannel(e\SoundCHN)
+				StopChannel(e\SoundCHN)
 			Else
-				StopStream_Strict(e\SoundCHN)
+				StopStream_Strict(e\SoundCHN) : e\SoundCHN_isStream = False
 			EndIf
+			e\SoundCHN = 0
 		EndIf
 		If e\SoundCHN2 <> 0 Then
 			If (Not e\SoundCHN2_isStream)
-				If ChannelPlaying(e\SoundCHN2) Then StopChannel(e\SoundCHN2)
+				StopChannel(e\SoundCHN2)
 			Else
-				StopStream_Strict(e\SoundCHN2)
+				StopStream_Strict(e\SoundCHN2) : e\SoundCHN2_isStream = False
 			EndIf
+			e\SoundCHN2 = 0
 		EndIf		
 	Next
 	For n.NPCs = Each NPCs
 		If n\SoundChn <> 0 Then
 			If (Not n\SoundChn_IsStream)
-				If ChannelPlaying(n\SoundChn) Then StopChannel(n\SoundChn)
+				StopChannel(n\SoundChn)
 			Else
-				StopStream_Strict(n\SoundChn)
+				StopStream_Strict(n\SoundChn) : n\SoundChn_isStream = False
 			EndIf
+			n\SoundChn = 0
 		EndIf
 		If n\SoundChn2 <> 0 Then
 			If (Not n\SoundChn2_IsStream)
-				If ChannelPlaying(n\SoundChn2) Then StopChannel(n\SoundChn2)
+				StopChannel(n\SoundChn2)
 			Else
-				StopStream_Strict(n\SoundChn2)
+				StopStream_Strict(n\SoundChn2) : n\SoundChn2_isStream = False
 			EndIf
+			n\SoundChn2 = 0
 		EndIf
 	Next	
 	For d.Doors = Each Doors
 		If d\SoundCHN <> 0 Then
-			If ChannelPlaying(d\SoundCHN) Then StopChannel(d\SoundCHN)
+			StopChannel(d\SoundCHN) : d\SoundCHN = 0
 		EndIf
 	Next
 	For dem.DevilEmitters = Each DevilEmitters
 		If dem\SoundCHN <> 0 Then
-			If ChannelPlaying(dem\SoundCHN) Then StopChannel(dem\SoundCHN)
+			StopChannel(dem\SoundCHN) : dem\SoundCHN = 0
 		EndIf
 	Next
 	If AmbientSFXCHN <> 0 Then
-		If ChannelPlaying(AmbientSFXCHN) Then StopChannel(AmbientSFXCHN)
+		StopChannel(AmbientSFXCHN) : AmbientSFXCHN = 0
 	EndIf
 	If BreathCHN <> 0 Then
-		If ChannelPlaying(BreathCHN) Then StopChannel(BreathCHN)
+		StopChannel(BreathCHN) : BreathCHN = 0
 	EndIf
+	If CoughCHN <> 0 Then
+		StopChannel(CoughCHN) : CoughCHN = 0
+	EndIf
+	If VomitCHN <> 0 Then
+		StopChannel(VomitCHN) : VomitCHN = 0
+	EndIf
+	For i = 0 To 6
+		If RadioCHN(i) <> 0 Then
+			StopChannel(RadioCHN(i)) : RadioCHN(i) = 0
+		EndIf
+	Next
 	If IntercomStreamCHN <> 0
-		StopStream_Strict(IntercomStreamCHN)
-		IntercomStreamCHN = 0
+		StopStream_Strict(IntercomStreamCHN) : IntercomStreamCHN = 0
 	EndIf
 	If EnableSFXRelease
 		For snd.Sound = Each Sound
@@ -9259,7 +9283,7 @@ Function KillSounds()
 	For snd.Sound = Each Sound
 		For i = 0 To 31
 			If snd\channels[i]<>0 Then
-				StopChannel snd\channels[i]
+				StopChannel snd\channels[i] : snd\channels[i] = 0
 			EndIf
 		Next
 	Next
@@ -9326,42 +9350,50 @@ Function GetStepSound(entity%)
 End Function
 
 Function UpdateSoundOrigin2(Chn%, cam%, entity%, range# = 10, volume# = 1.0)
-	range# = Max(range,1.0)
-	
-	If volume>0 Then
-		
-		Local dist# = EntityDistance(cam, entity) / range#
-		If 1 - dist# > 0 And 1 - dist# < 1 Then
+	If Chn <> 0 Then
+		If ChannelPlaying(Chn) Then
+			range# = Max(range,1.0)
 			
-			Local panvalue# = Sin(-DeltaYaw(cam,entity))
-			
-			ChannelVolume(Chn, volume# * (1 - dist#))
-			ChannelPan(Chn, panvalue)
+			If volume>0 Then
+				
+				Local dist# = EntityDistance(cam, entity) / range#
+				If 1 - dist# > 0 And 1 - dist# < 1 Then
+					
+					Local panvalue# = Sin(-DeltaYaw(cam,entity))
+					
+					ChannelVolume(Chn, volume# * (1 - dist#))
+					ChannelPan(Chn, panvalue)
+				Else
+					ChannelVolume (Chn, 0)
+				EndIf
+			Else
+				ChannelVolume (Chn, 0)
+			EndIf
 		EndIf
-	Else
-		If Chn <> 0 Then
-			ChannelVolume (Chn, 0)
-		EndIf 
 	EndIf
 End Function
 
 Function UpdateSoundOrigin(Chn%, cam%, entity%, range# = 10, volume# = 1.0)
-	range# = Max(range,1.0)
-	
-	If volume>0 Then
-		
-		Local dist# = EntityDistance(cam, entity) / range#
-		If 1 - dist# > 0 And 1 - dist# < 1 Then
+	If Chn <> 0 Then
+		If ChannelPlaying(Chn) Then
+			range# = Max(range,1.0)
 			
-			Local panvalue# = Sin(-DeltaYaw(cam,entity))
-			
-			ChannelVolume(Chn, volume# * (1 - dist#)*SFXVolume#)
-			ChannelPan(Chn, panvalue)
+			If volume>0 Then
+				
+				Local dist# = EntityDistance(cam, entity) / range#
+				If 1 - dist# > 0 And 1 - dist# < 1 Then
+					
+					Local panvalue# = Sin(-DeltaYaw(cam,entity))
+					
+					ChannelVolume(Chn, volume# * (1 - dist#)*SFXVolume#)
+					ChannelPan(Chn, panvalue)
+				Else
+					ChannelVolume (Chn, 0)
+				EndIf
+			Else
+				ChannelVolume (Chn, 0)
+			EndIf
 		EndIf
-	Else
-		If Chn <> 0 Then
-			ChannelVolume (Chn, 0)
-		EndIf 
 	EndIf
 End Function
 ;--------------------------------------- random -------------------------------------------------------
@@ -11803,8 +11835,7 @@ End Function
 Function PlayAnnouncement(file$) ;This function streams the announcement currently playing
 	
 	If IntercomStreamCHN <> 0 Then
-		StopStream_Strict(IntercomStreamCHN)
-		IntercomStreamCHN = 0
+		StopStream_Strict(IntercomStreamCHN) : IntercomStreamCHN = 0
 	EndIf
 	
 	IntercomStreamCHN = StreamSound_Strict(file$,SFXVolume,0)
@@ -11835,20 +11866,19 @@ Function UpdateStreamSounds()
 	If (Not PlayerInReachableRoom()) Then
 		If PlayerRoom\RoomTemplate\Name <> "exit1" And PlayerRoom\RoomTemplate\Name <> "gatea" Then
 			If IntercomStreamCHN <> 0 Then
-				StopStream_Strict(IntercomStreamCHN)
-				IntercomStreamCHN = 0
+				StopStream_Strict(IntercomStreamCHN) : IntercomStreamCHN = 0
 			EndIf
 			If PlayerRoom\RoomTemplate\Name$ <> "dimension1499" Then
 				For e = Each Events
-					If e\SoundCHN<>0 And e\SoundCHN_isStream Then
-						StopStream_Strict(e\SoundCHN)
-						e\SoundCHN = 0
-						e\SoundCHN_isStream = 0
+					If e\SoundCHN<>0 Then
+						If e\SoundCHN_isStream Then
+							StopStream_Strict(e\SoundCHN) : e\SoundCHN = 0 : e\SoundCHN_isStream = False
+						EndIf
 					EndIf
-					If e\SoundCHN2<>0 And e\SoundCHN2_isStream Then
-						StopStream_Strict(e\SoundCHN2)
-						e\SoundCHN2 = 0
-						e\SoundCHN2_isStream = 0
+					If e\SoundCHN2<>0 Then
+						If e\SoundCHN2_isStream Then
+							StopStream_Strict(e\SoundCHN2) : e\SoundCHN2 = 0 : e\SoundCHN2_isStream = False
+						EndIf
 					EndIf
 				Next
 			EndIf

--- a/NPCs.bb
+++ b/NPCs.bb
@@ -638,28 +638,26 @@ Function RemoveNPC(n.NPCs)
 		n\obj4 = 0
 	EndIf
 	
-	If (Not n\SoundChn_IsStream)
-		If (n\SoundChn <> 0 And ChannelPlaying(n\SoundChn)) Then
+	If n\SoundChn <> 0 Then
+		If (Not n\SoundChn_IsStream)
 			StopChannel(n\SoundChn)
+		Else
+			StopStream_Strict(n\SoundChn) : n\SoundChn_IsStream = False
 		EndIf
-	Else
-		If (n\SoundChn <> 0)
-			StopStream_Strict(n\SoundChn)
-		EndIf
+		n\SoundChn = 0
 	EndIf
 	
-	If (Not n\SoundChn2_IsStream)
-		If (n\SoundChn2 <> 0 And ChannelPlaying(n\SoundChn2)) Then
+	If n\SoundChn2 <> 0 Then
+		If (Not n\SoundChn2_IsStream)
 			StopChannel(n\SoundChn2)
+		Else
+			StopStream_Strict(n\SoundChn2) : n\SoundChn2_IsStream = False
 		EndIf
-	Else
-		If (n\SoundChn2 <> 0)
-			StopStream_Strict(n\SoundChn2)
-		EndIf
+		n\SoundChn2 = 0
 	EndIf
 	
-	If n\Sound<>0 Then FreeSound_Strict n\Sound
-	If n\Sound2<>0 Then FreeSound_Strict n\Sound2
+	If n\Sound<>0 Then FreeSound_Strict n\Sound : n\Sound = 0
+	If n\Sound2<>0 Then FreeSound_Strict n\Sound2 : n\Sound2 = 0
 	
 	FreeEntity(n\obj) : n\obj = 0
 	FreeEntity(n\Collider) : n\Collider = 0	
@@ -1256,9 +1254,8 @@ Function UpdateNPCs()
 							If n\SoundChn = 0
 								n\SoundChn = StreamSound_Strict("SFX\Music\096.ogg",0)
 								n\SoundChn_IsStream = True
-							Else
-								UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,8.0,1.0)
 							EndIf
+							UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,8.0,1.0)
 							
 							If n\State3 = -1
 								AnimateNPC(n,936,1263,0.1,False)
@@ -1297,7 +1294,9 @@ Function UpdateNPCs()
 													
 													n\Frame = 194
 													;n\Frame = 307
-													StopStream_Strict(n\SoundChn) : n\SoundChn=0
+													If n\SoundChn <> 0 Then
+														StopStream_Strict(n\SoundChn) : n\SoundChn = 0 : n\SoundChn_IsStream = False
+													EndIf
 													n\Sound = 0
 													n\State = 1
 													n\State3 = 0
@@ -1323,9 +1322,8 @@ Function UpdateNPCs()
 							If n\SoundChn = 0
 								n\SoundChn = StreamSound_Strict("SFX\SCP\096\Scream.ogg",0)
 								n\SoundChn_IsStream = True
-							Else
-								UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,7.5,1.0)
 							EndIf
+							UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,7.5,1.0)
 							
 							;If n\Sound2 = 0 Then
 							;	n\Sound2 = LoadSound_Strict("SFX\Music\096Chase.ogg")
@@ -1339,7 +1337,7 @@ Function UpdateNPCs()
 							;EndIf
 							If n\SoundChn2 = 0
 								n\SoundChn2 = StreamSound_Strict("SFX\Music\096Chase.ogg",0)
-								n\SoundChn2_IsStream = 2
+								n\SoundChn2_IsStream = True
 							Else
 								SetStreamVolume_Strict(n\SoundChn2,Min(Max(8.0-dist,0.6),1.0)*SFXVolume#)
 							EndIf
@@ -1504,9 +1502,8 @@ Function UpdateNPCs()
 						If n\SoundChn = 0
 							n\SoundChn = StreamSound_Strict("SFX\Music\096Angered.ogg",0)
 							n\SoundChn_IsStream = True
-						Else
-							UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,10.0,1.0)
 						EndIf
+						UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,10.0,1.0)
 						
 						If n\State=1 Then ; get up
 							If n\Frame<312
@@ -1538,7 +1535,9 @@ Function UpdateNPCs()
 								;AnimateNPC(n, 973, 1001, 0.5, False)
 								If n\Frame>846.9 Then ;1000.9 
 									n\State = 4
-									StopStream_Strict(n\SoundChn) : n\SoundChn=0
+									If n\SoundChn <> 0 Then
+										StopStream_Strict(n\SoundChn) : n\SoundChn = 0 : n\SoundChn_IsStream = False
+									EndIf
 								EndIf
 							Else
 								AnimateNPC(n,737,822,0.3)
@@ -1562,9 +1561,8 @@ Function UpdateNPCs()
 							If n\SoundChn = 0
 								n\SoundChn = StreamSound_Strict("SFX\Music\096.ogg",0)
 								n\SoundChn_IsStream = True
-							Else
-								UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,14.0,1.0)
 							EndIf
+							UpdateStreamSoundOrigin(n\SoundChn,Camera,n\Collider,14.0,1.0)
 							
 							If n\Frame>=422
 								n\State2=n\State2+FPSfactor
@@ -1639,7 +1637,9 @@ Function UpdateNPCs()
 													If n\Frame >= 422
 														n\Frame = 677 ;833
 													EndIf
-													StopStream_Strict(n\SoundChn) : n\SoundChn=0
+													If n\SoundChn <> 0 Then
+														StopStream_Strict(n\SoundChn) : n\SoundChn = 0 : n\SoundChn_IsStream = False
+													EndIf
 													n\Sound = 0
 													n\State = 2
 												EndIf
@@ -1995,9 +1995,7 @@ Function UpdateNPCs()
 									EndIf
 								EndIf
 								
-								If ChannelPlaying(n\SoundChn2)
-									UpdateSoundOrigin(n\SoundChn2,Camera,n\obj)
-								EndIf
+								UpdateSoundOrigin(n\SoundChn2,Camera,n\obj)
 							ElseIf (Not n\Idle)
 								If ChannelPlaying(n\SoundChn) Then
 									StopChannel(n\SoundChn)
@@ -2135,9 +2133,7 @@ Function UpdateNPCs()
 								EndIf
 							EndIf
 							
-							If ChannelPlaying(n\SoundChn2)
-								UpdateSoundOrigin(n\SoundChn2,Camera,n\obj)
-							EndIf
+							UpdateSoundOrigin(n\SoundChn2,Camera,n\obj)
 							;[End Block]
 					End Select
 				EndIf
@@ -4044,9 +4040,9 @@ Function UpdateNPCs()
 				EndIf
 				
 				If ChannelPlaying(n\SoundChn2)
-					UpdateSoundOrigin2(n\SoundChn2,Camera,n\Collider,20)
 					BlurTimer = Max((5.0-dist)*300,0)
 				EndIf
+				UpdateSoundOrigin2(n\SoundChn2,Camera,n\Collider,20)
 				
 				PositionEntity(n\obj, EntityX(n\Collider), EntityY(n\Collider) - 0.2, EntityZ(n\Collider))
 				
@@ -4785,9 +4781,7 @@ Function UpdateNPCs()
 							;[End Block]
 					End Select
 					
-					If n\SoundChn <> 0 And ChannelPlaying(n\SoundChn) Then
-						UpdateSoundOrigin(n\SoundChn,Camera,n\Collider,20.0)
-					EndIf
+					UpdateSoundOrigin(n\SoundChn,Camera,n\Collider,20.0)
 					
 					MoveEntity n\Collider,0,0,n\CurrSpeed*FPSfactor
 					

--- a/StrictLoads.bb
+++ b/StrictLoads.bb
@@ -276,25 +276,27 @@ Function SetStreamPan_Strict(streamHandle%,pan#)
 End Function
 
 Function UpdateStreamSoundOrigin(streamHandle%,cam%,entity%,range#=10,volume#=1.0)
-	;Local st.Stream = Object.Stream(streamHandle)
-	range# = Max(range,1.0)
-	
-	If volume>0 Then
-		
-		Local dist# = EntityDistance(cam, entity) / range#
-		If 1 - dist# > 0 And 1 - dist# < 1 Then
+	If streamHandle <> 0 Then
+		If IsStreamPlaying_Strict(streamHandle) Then
+			;Local st.Stream = Object.Stream(streamHandle)
+			range# = Max(range,1.0)
 			
-			Local panvalue# = Sin(-DeltaYaw(cam,entity))
-			
-			SetStreamVolume_Strict(streamHandle,volume#*(1-dist#)*SFXVolume#)
-			SetStreamPan_Strict(streamHandle,panvalue)
-		Else
-			SetStreamVolume_Strict(streamHandle,0.0)
+			If volume>0 Then
+				
+				Local dist# = EntityDistance(cam, entity) / range#
+				If 1 - dist# > 0 And 1 - dist# < 1 Then
+					
+					Local panvalue# = Sin(-DeltaYaw(cam,entity))
+					
+					SetStreamVolume_Strict(streamHandle,volume#*(1-dist#)*SFXVolume#)
+					SetStreamPan_Strict(streamHandle,panvalue)
+				Else
+					SetStreamVolume_Strict(streamHandle,0.0)
+				EndIf
+			Else
+				SetStreamVolume_Strict(streamHandle,0.0)
+			EndIf
 		EndIf
-	Else
-		If streamHandle <> 0 Then
-			SetStreamVolume_Strict(streamHandle,0.0)
-		EndIf 
 	EndIf
 End Function
 

--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -1536,12 +1536,8 @@ Function UpdateEvents()
 				
 				e\EventState = e\room\RoomDoors[0]\open
 				
-				If ChannelPlaying(e\SoundCHN)
-					UpdateSoundOrigin(e\SoundCHN,Camera,e\room\RoomDoors[0]\obj)
-				EndIf
-				If ChannelPlaying(e\SoundCHN2)
-					UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\RoomDoors[1]\obj)
-				EndIf
+				UpdateSoundOrigin(e\SoundCHN,Camera,e\room\RoomDoors[0]\obj)
+				UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\RoomDoors[1]\obj)
 				;[End Block]
 			Case "coffin", "coffin106"
 				;[Block]
@@ -4391,8 +4387,9 @@ Function UpdateEvents()
 							ScaleSprite(de\obj, de\Size,de\Size)
 							
 							Curr096\State=5
-							StopStream_Strict(Curr096\SoundChn)
-							Curr096\SoundChn=0
+							If Curr096\SoundChn <> 0 Then
+								StopStream_Strict(Curr096\SoundChn) : Curr096\SoundChn=0 : Curr096\SoundChn_isStream = False
+							EndIf
 							
 							RemoveNPC(e\room\NPC[0])
 							e\room\NPC[0]=Null
@@ -4990,9 +4987,7 @@ Function UpdateEvents()
 									e\room\NPC[2]\IgnorePlayer = True
 							End Select
 							
-							If ChannelPlaying(e\SoundCHN2)
-								UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\RoomDoors[4]\obj,400)
-							EndIf
+							UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\RoomDoors[4]\obj,400)
 							
 							PlayerFallingPickDistance = 0.0
 							
@@ -5927,28 +5922,33 @@ Function UpdateEvents()
 								;e\Sound = LoadSound_Strict("SFX\SCP\079\Speech.ogg")
 								;LoadEventSound(e,"SFX\SCP\079\Speech.ogg")
 								;e\SoundCHN = PlaySound_Strict (e\Sound)
+								If e\SoundCHN<>0
+									StopStream_Strict(e\SoundCHN) : e\SoundCHN=0 : e\SoundCHN_isStream = False
+								EndIf
 								e\SoundCHN = StreamSound_Strict("SFX\SCP\079\Speech.ogg",SFXVolume,0)
 								e\SoundCHN_isStream = True
 							EndIf							
 						;ElseIf e\EventState = 3
-						ElseIf e\EventState < 2000 Then ;3500
+						ElseIf e\EventState < 6000 Then ;3500
 							;If ChannelPlaying(e\SoundCHN) Then
-							If IsStreamPlaying_Strict(e\SoundCHN)
-								If Rand(3) = 1 Then
-									EntityTexture(e\room\Objects[1], OldAiPics(0))
+							If e\SoundCHN <> 0 Then
+								If IsStreamPlaying_Strict(e\SoundCHN)
+									If Rand(3) = 1 Then
+										EntityTexture(e\room\Objects[1], OldAiPics(0))
+										ShowEntity (e\room\Objects[1])
+									ElseIf Rand(10) = 1 
+										HideEntity (e\room\Objects[1])							
+									EndIf							
+								Else
+									;If e\Sound <> 0 Then FreeSound_Strict e\Sound : e\Sound = 0
+									If e\SoundCHN<>0
+										StopStream_Strict(e\SoundCHN) : e\SoundCHN=0 : e\SoundCHN_isStream = False
+									EndIf
+									EntityTexture(e\room\Objects[1], OldAiPics(1))
 									ShowEntity (e\room\Objects[1])
-								ElseIf Rand(10) = 1 
-									HideEntity (e\room\Objects[1])							
-								EndIf							
-							Else
-								;If e\Sound <> 0 Then FreeSound_Strict e\Sound : e\Sound = 0
-								If e\SoundCHN<>0
-									StopStream_Strict(e\SoundCHN) : e\SoundCHN=0
 								EndIf
-								EntityTexture(e\room\Objects[1], OldAiPics(1))
-								ShowEntity (e\room\Objects[1])
-								e\EventState = e\EventState + FPSfactor
 							EndIf
+							e\EventState = e\EventState + FPSfactor
 						Else
 							If EntityDistance(e\room\Objects[0], Collider)<2.5 Then 
 								e\EventState = 10001
@@ -5956,9 +5956,10 @@ Function UpdateEvents()
 								;LoadEventSound(e,"SFX\SCP\079\Refuse.ogg")
 								;e\SoundCHN = PlaySound_Strict (e\Sound)
 								If e\SoundCHN<>0
-									StopStream_Strict(e\SoundCHN) : e\SoundCHN=0
+									StopStream_Strict(e\SoundCHN) : e\SoundCHN=0 : e\SoundCHN_isStream = False
 								EndIf
 								e\SoundCHN = StreamSound_Strict("SFX\SCP\079\Refuse.ogg",SFXVolume,0)
+								e\SoundCHN_isStream = True
 								;EntityTexture(e\room\Objects[1], OldAiPics(1))
 								;ShowEntity (e\room\Objects[1])
 							EndIf
@@ -5966,7 +5967,9 @@ Function UpdateEvents()
 					Else
 						If e\SoundCHN<>0
 							If (Not IsStreamPlaying_Strict(e\SoundCHN))
-								e\SoundCHN = 0
+								If e\SoundCHN<>0
+									StopStream_Strict(e\SoundCHN) : e\SoundCHN=0 : e\SoundCHN_isStream = False
+								EndIf
 								EntityTexture(e\room\Objects[1], OldAiPics(1))
 								ShowEntity (e\room\Objects[1])
 							Else
@@ -5988,7 +5991,7 @@ Function UpdateEvents()
 						;LoadEventSound(e,"SFX\SCP\079\GateB.ogg")
 						;e\SoundCHN = PlaySound_Strict (e\Sound)
 						If e\SoundCHN<>0
-							StopStream_Strict(e\SoundCHN) : e\SoundCHN=0
+							StopStream_Strict(e\SoundCHN) : e\SoundCHN=0 : e\SoundCHN_isStream = False
 						EndIf
 						e\SoundCHN = StreamSound_Strict("SFX\SCP\079\GateB.ogg",SFXVolume,0)
 						e\SoundCHN_isStream = True
@@ -7739,9 +7742,8 @@ Function UpdateEvents()
 							If (Not ChannelPlaying(e\SoundCHN))
 								e\EventState = 2.0
 								e\room\RoomDoors[0]\locked = False
-							Else
-								UpdateSoundOrigin(e\SoundCHN,Camera,e\room\Objects[0],100,1.0)
 							EndIf
+							UpdateSoundOrigin(e\SoundCHN,Camera,e\room\Objects[0],100,1.0)
 						EndIf
 					Else
 						DebugLog "Removed 'room2scps2' event"
@@ -8096,13 +8098,9 @@ Function UpdateEvents()
 					EndIf
 					
 					If brokendoor
-						If ChannelPlaying(e\SoundCHN2)
-							UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\Objects[1],5)
-						EndIf
+						UpdateSoundOrigin(e\SoundCHN2,Camera,e\room\Objects[1],5)
 					EndIf
-					If ChannelPlaying(e\SoundCHN)
-						UpdateSoundOrigin(e\SoundCHN,Camera,e\room\Objects[0],5)
-					EndIf
+					UpdateSoundOrigin(e\SoundCHN,Camera,e\room\Objects[0],5)
 				Else
 					e\EventState3 = 0.0
 				EndIf
@@ -8618,10 +8616,10 @@ Function UpdateEvents()
 				EndIf
 				If e\EventState = 2.0
 					If e\SoundCHN<>0 Then
-						StopStream_Strict(e\SoundCHN)
-						StopChannel(e\SoundCHN2)
-						e\SoundCHN = 0
-						e\SoundCHN2 = 0
+						StopStream_Strict(e\SoundCHN) : e\SoundCHN = 0 : e\SoundCHN_isStream = False
+					EndIf
+					If e\SoundCHN2<>0 Then
+						StopChannel(e\SoundCHN2) : e\SoundCHN2 = 0
 					EndIf
 					HideEntity NTF_1499Sky
 					HideChunks()
@@ -9103,10 +9101,10 @@ Function UpdateDimension1499()
 						Else
 							ShouldPlay = 19
 							If e\SoundCHN<>0 Then
-								StopStream_Strict(e\SoundCHN)
-								StopChannel(e\SoundCHN2)
-								e\SoundCHN = 0
-								e\SoundCHN2 = 0
+								StopStream_Strict(e\SoundCHN) : e\SoundCHN = 0 : e\SoundCHN_isStream = False
+							EndIf
+							If e\SoundCHN2<>0 Then
+								StopChannel(e\SoundCHN2) : e\SoundCHN2 = 0
 							EndIf
 							If e\Sound2 <> 0 Then
 								FreeSound_Strict e\Sound2
@@ -9132,10 +9130,10 @@ Function UpdateDimension1499()
 			Else
 				If e\EventState = 2.0
 					If e\SoundCHN<>0 Then
-						StopStream_Strict(e\SoundCHN)
-						StopChannel(e\SoundCHN2)
-						e\SoundCHN = 0
-						e\SoundCHN2 = 0
+						StopStream_Strict(e\SoundCHN) : e\SoundCHN = 0 : e\SoundCHN_isStream = False
+					EndIf
+					If e\SoundCHN2<>0 Then
+						StopChannel(e\SoundCHN2) : e\SoundCHN2 = 0
 					EndIf
 					HideEntity NTF_1499Sky
 					HideChunks()
@@ -9349,8 +9347,12 @@ Function UpdateEndings()
 									If SelectedEnding = "" Then
 									    ShouldPlay = 66
 										
-										StopStream_Strict(e\SoundCHN)
-										StopStream_Strict(e\SoundCHN2)
+										If e\SoundCHN <> 0 Then
+											StopStream_Strict(e\SoundCHN) : e\SoundCHN = 0 : e\SoundCHN_isStream = False
+										EndIf
+										If e\SoundCHN2 <> 0 Then
+											StopStream_Strict(e\SoundCHN2) : e\SoundCHN2 = 0 : e\SoundCHN2_isStream = False
+										EndIf
 										
 										temp = True
 										For e2.Events = Each Events


### PR DESCRIPTION
- Removed unnecessary ``ChannelPlaying`` checks from ``RemoveNPC``, ``KillSounds``, ``ResumeSounds`` and ``PauseSounds`` function. We don't need to check if the sound is playing, enough to know does it exist or not;
- Added ``CoughCHN``, ``VomitCHN`` and ``RadioCHN`` to ``PauseSounds``, ``ResumeSounds`` and ``KillSounds`` function;
- Added channel existing check for ``UpdateSoundOrigin(2)`` and ``UpdateStreamSoundOrigin`` function, so we don't need to check manually if the sound is existing. First, we don't need to try apply channel functions to null channel and produce unnecessary calculations. Second, added sound playing check because we need to use these functions only when the sound is playing.
- Completely remove sound from memory. As you know, ``FreeSound``, ``StopChannel`` and etc. don't finally frees the memory, so I added ``CHN = 0`` lines.
- Fixed spammable ``Failed to find stream Sound: Unknown Stream`` console error appearing in:
1) SCP-079's chamber after finishing ``Speech.ogg`` sound;
2) Gate B area after playing ``AlphaWarheadsFail.ogg`` sound;
3) I'm not sure, but sometimes I saw this error for SCP-096. I noticed ``n\SoundChn2_IsStream = 2`` line that should have ``True`` value instead of ``2``. Maybe it shouldn't, who knows ¯\_(ツ)_/¯ ;
Always reset ``_isStream`` parameter while removing a channel for preventing any confuses in ``UpdateStreamSounds`` function. Also added more sound exist checks for preventing ``Unknow stream`` error;
- Added ``ChannelVolume (Chn, 0)`` line to ``UpdateSoundOrigin(2)`` function to prevent sound from being assigned a negative volume when sound emitter out of range.
- Separated some conditions. First, we should check if the sounds exist. After, check if the sound is stream sound. Don't waste your time time to check them both.

Note:
- ``RadioCHN`` channel placed only in ``KillSounds`` because placing in ``ResumeSounds`` and ``PauseSounds`` doesn't affect on the channel. To do!