### PR TITLE
Difficulty enhancements

### DIFF
--- a/Difficulty.bb
+++ b/Difficulty.bb
@@ -69,7 +69,7 @@ difficulties(CUSTOM)\r = 255
 difficulties(CUSTOM)\g = 255
 difficulties(CUSTOM)\b = 255
 
-SelectedDifficulty = difficulties(SAFE)
+SelectedDifficulty = difficulties(EUCLID)
 ;~IDEal Editor Parameters:
 ;~F#0
 ;~C#Blitz3D

--- a/Difficulty.bb
+++ b/Difficulty.bb
@@ -59,7 +59,7 @@ difficulties(KETER)\g = 0
 difficulties(KETER)\b = 0
 
 difficulties(CUSTOM) = New Difficulty
-difficulties(CUSTOM)\name = "Custom"
+difficulties(CUSTOM)\name = "Esoteric"
 difficulties(CUSTOM)\permaDeath = False
 difficulties(CUSTOM)\aggressiveNPCs = True
 difficulties(CUSTOM)\saveType = SAVEANYWHERE


### PR DESCRIPTION
"Esoteric" is a cutesy nod to the [esoteric](https://scp-wiki.wikidot.com/object-classes#:~:text=click%20here.-,Esoteric/Narrative%20Classes,-Esoteric%20Object%20Classes) meta object class and Euclid being made the standard communicates the suggestion that it is to be considered the "standard" difficulty as well as the way CB is "meant" to be played (which it honestly is), besides the middle difficulty also being the default in most other games.