### PR TITLE
Fixes to 049

### DIFF
--- a/NPCs.bb
+++ b/NPCs.bb
@@ -1679,7 +1679,7 @@ Function UpdateNPCs()
 					If ChannelPlaying(n\SoundChn) Then StopChannel(n\SoundChn)
 					If ChannelPlaying(n\SoundChn2) Then StopChannel(n\SoundChn2)
 					PositionEntity n\Collider,0,-500,0
-					PositionEntity n\obj,0,-500,0
+					ResetEntity n\Collider
 				Else
 					If n\Idle = 0.1 Then
 						If PlayerInReachableRoom() Then

--- a/NPCs.bb
+++ b/NPCs.bb
@@ -1687,8 +1687,10 @@ Function UpdateNPCs()
 								If PlayerRoom\Adjacent[i]<>Null Then
 									For j = 0 To 3
 										If PlayerRoom\Adjacent[i]\Adjacent[j]<>Null Then
-											TeleportEntity(n\Collider,PlayerRoom\Adjacent[i]\Adjacent[j]\x,0.5,PlayerRoom\Adjacent[i]\Adjacent[j]\z,n\CollRadius,True)
-											Exit
+											If PlayerRoom\Adjacent[i]\Adjacent[j]<>PlayerRoom Then
+												TeleportEntity(n\Collider,PlayerRoom\Adjacent[i]\Adjacent[j]\x,0.5,PlayerRoom\Adjacent[i]\Adjacent[j]\z,n\CollRadius,True)
+												Exit
+											EndIf
 										EndIf
 									Next
 									Exit


### PR DESCRIPTION
### 31d2f8ff13d95feecc11c910de7dcbb0847eee33 Fix 049 teleporting to player room
There's a block of code in `UpdateNPCs` that would teleport 049 to a room adjacent to a room adjacent to the player room. Well, the player room itself is a room adjacent to a room adjacent to the player room. See commit for more info.

### 55c6f817fe99315312053944b3fb2e5e088c3b86 Fix 049 appearing on blue NVG interface while idle
When 049 is idle, the game positions his collider to 0,-500,0, but because ResetEntity isn't called, his collider collides with the floor and remains above ground while his model successfully goes below ground because it has no collision. This results in 049's collider showing up on the blue NVG interface even though he is idle and his model can't be seen. See commit for more info.