### PR TITLE
Fixes and improvements to 049 removing hazmat suit/714

### DIFF
--- a/Items.bb
+++ b/Items.bb
@@ -587,7 +587,7 @@ Function UpdateItems()
 		deletedItem = False
 	Next
 	
-	If ClosestItem <> Null Then
+	If ClosestItem <> Null And KillTimer >= 0 Then
 		;DrawHandIcon = True
 		
 		If MouseHit1 Then PickItem(ClosestItem)

--- a/Main.bb
+++ b/Main.bb
@@ -4710,7 +4710,7 @@ Function DrawGUI()
 		EndIf
 	EndIf
 	
-	If ClosestItem <> Null Then
+	If ClosestItem <> Null And KillTimer >= 0 Then
 		yawvalue# = -DeltaYaw(Camera, ClosestItem\collider)
 		If yawvalue > 90 And yawvalue <= 180 Then yawvalue = 90
 		If yawvalue > 180 And yawvalue < 270 Then yawvalue = 270

--- a/Main.bb
+++ b/Main.bb
@@ -292,6 +292,7 @@ Global SCP1025state#[6]
 Global HeartBeatRate#, HeartBeatTimer#, HeartBeatVolume#
 
 Global WearingGasMask%, WearingHazmat%, WearingVest%, Wearing714%, WearingNightVision%
+Global RemoveHazmatTimer#, Remove714Timer#
 Global NVTimer#
 
 Global SuperMan%, SuperManTimer#
@@ -8776,6 +8777,8 @@ Function NullGame(playbuttonsfx%=True)
 		CameraFogFar = StoredCameraFogFar
 		WearingNightVision = 0
 	EndIf
+	RemoveHazmatTimer = 0.0
+	Remove714Timer = 0.0
 	I_427\Using = 0
 	I_427\Timer = 0.0
 	

--- a/NPCs.bb
+++ b/NPCs.bb
@@ -1741,37 +1741,46 @@ Function UpdateNPCs()
 									RotateEntity n\Collider,0,CurveAngle(EntityYaw(n\obj),EntityYaw(n\Collider),10.0),0
 									
 									If dist < 0.5 Then
-										If WearingHazmat>0 Then
-											BlurTimer = BlurTimer+FPSfactor*2.5
-											If BlurTimer>250 And BlurTimer-FPSfactor*2.5 <= 250 And n\PrevState<>3 Then
-												If n\SoundChn2 <> 0 Then StopChannel(n\SoundChn2)
+										If WearingHazmat > 0 Then
+											RemoveHazmatTimer = RemoveHazmatTimer + FPSfactor*1.5
+											
+											If RemoveHazmatTimer > 100 And RemoveHazmatTimer - FPSfactor*1.5 <= 100 And (Not ChannelPlaying(n\SoundChn2)) Then
 												n\SoundChn2 = PlaySound_Strict(LoadTempSound("SFX\SCP\049\TakeOffHazmat.ogg"))
-												n\PrevState=3
-											ElseIf BlurTimer => 500
-												For i = 0 To MaxItemAmount-1
-													If Inventory(i)<>Null Then
-														If Instr(Inventory(i)\itemtemplate\tempname,"hazmatsuit") And WearingHazmat<3 Then
-															If Inventory(i)\state2 < 3 Then
-																Inventory(i)\state2 = Inventory(i)\state2 + 1
-																BlurTimer = 260.0
-																CameraShake = 2.0
-															Else
-																RemoveItem(Inventory(i))
-																WearingHazmat = False
-															EndIf
-															Exit
+											ElseIf RemoveHazmatTimer > 500 Then
+												For i = 0 To 3
+													If RemoveHazmatTimer > 500 + i*240 And RemoveHazmatTimer - FPSfactor*1.5 <= 500 + i*240 Then
+														CameraShake = 2.0
+														If i = 3 Then
+															For i = 0 To MaxItemAmount - 1
+																If Inventory(i) <> Null Then
+																	If Instr(Inventory(i)\itemtemplate\tempname, "hazmatsuit") Then
+																		WearingHazmat = False : DropItem(Inventory(i))
+																		Msg = "The hazmat suit was forcibly removed." : MsgTimer = 70*5
+																		Exit
+																	EndIf
+																EndIf
+															Next
 														EndIf
 													EndIf
 												Next
 											EndIf
 										ElseIf Wearing714 Then
-											BlurTimer = BlurTimer+FPSfactor*2.5
-											If BlurTimer>250 And BlurTimer-FPSfactor*2.5 <= 250 And n\PrevState<>3 Then
-												If n\SoundChn2 <> 0 Then StopChannel(n\SoundChn2)
+											BlurTimer = BlurTimer + FPSfactor*2.5
+											
+											Remove714Timer = Remove714Timer + FPSfactor*1.5
+											
+											If Remove714Timer > 100 And Remove714Timer - FPSfactor*1.5 <= 100 And (Not ChannelPlaying(n\SoundChn2)) Then
 												n\SoundChn2 = PlaySound_Strict(LoadTempSound("SFX\SCP\049\714Equipped.ogg"))
-												n\PrevState=3
-											ElseIf BlurTimer => 500
-												Wearing714=False
+											ElseIf Remove714Timer > 500 Then
+												For i = 0 To MaxItemAmount - 1
+													If Inventory(i) <> Null Then
+														If Inventory(i)\itemtemplate\tempname = "scp714" Then
+															Wearing714 = False : DropItem(Inventory(i))
+															Msg = "The ring was forcibly removed." : MsgTimer = 70*5
+															Exit
+														EndIf
+													EndIf
+												Next
 											EndIf
 										Else
 											CurrCameraZoom = 20.0
@@ -1795,10 +1804,11 @@ Function UpdateNPCs()
 											EndIf										
 										EndIf
 									Else
+										RemoveHazmatTimer = Max(RemoveHazmatTimer - FPSfactor, 0.0)
+										Remove714Timer = Max(Remove714Timer - FPSfactor, 0.0)
+										
 										n\CurrSpeed = CurveValue(n\Speed, n\CurrSpeed, 20.0)
 										MoveEntity n\Collider, 0, 0, n\CurrSpeed * FPSfactor	
-										
-										If n\PrevState = 3 Then n\PrevState = 2
 										
 										If dist < 3.0 Then
 											AnimateNPC(n, Max(Min(AnimTime(n\obj),428.0),387), 463.0, n\CurrSpeed*38)

--- a/Save.bb
+++ b/Save.bb
@@ -1308,6 +1308,9 @@ Function LoadGameQuick(file$)
 	LightFlash = 0
 	BlurTimer = 0
 	
+	RemoveHazmatTimer = 0.0
+	Remove714Timer = 0.0
+	
 	KillTimer = 0
 	FallTimer = 0
 	MenuOpen = False


### PR DESCRIPTION
Fixed + improved version of PR #179. I plan to record some footage of these changes and link it in an edit later.

### 4fe064823ac00b9cac6c1bbcc384d810f2ab8f20 Fixes and improvements to 049 removing hazmat suit/714
- Use two new globals as removal timers instead of BlurTimer, which fixes the issue where having blurry vision from another source (e.g. 420-J) causes 049 to remove the hazmat suit/714 sooner, as well as the issue where wearing both items at once causes 049 to only spend time removing the hazmat suit
- Hazmat suit now falls to the ground when removed by 049 instead of being inexplicably destroyed
- 714 now falls to the ground when removed by 049 instead of remaining in player's inventory (not that it matters much since the player dies afterwards)
- Add messages to make it clear to the player when an item is removed
- Make removal voice lines play sooner, replacing the initial awkward silence on contact and ensuring 049 is able to play a "kidnap" voice line on kill
- Previously, PrevState represented whether 049 had played a removal voice line, but it would reset to 2 the moment you backed away from 049, and would not allow both removal voice lines to play if you were wearing both items at once; now, ChannelPlaying checks are used instead, preventing removal voice lines from being spammable by repeatedly approaching and backing away from 049, and also allowing both removal voice lines to play

### ffdb4828e9647aa92775be967892e8c500480124 Remove ability to pick up items while dying
It was easy to pick up the dropped hazmat suit while dying after 049 removed it. This shouldn't be possible.