### PR TITLE
Tiny fix for "console commands"

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -1503,6 +1503,7 @@ Function UpdateConsole()
 End Function
 
 ConsoleR = 0 : ConsoleG = 255 : ConsoleB = 255
+CreateConsoleMsg("")
 CreateConsoleMsg("Console commands: ")
 CreateConsoleMsg("  - teleport [room name]")
 CreateConsoleMsg("  - godmode [on/off]")


### PR DESCRIPTION
Console has some messages by default, but the first line is "ignored".

In order to it can be shown in console, I add an empty line in the beginning.