### PR TITLE
Fix some events in custom maps

### DIFF
--- a/Data/events.ini
+++ b/Data/events.ini
@@ -71,7 +71,7 @@ room7=room4tunnels
 room8=room4pit
 room9=room3z2
 
-[roompj]
+[pj]
 descr=Spawns SCP-372 once the player enters the room.
 room1=roompj
 
@@ -115,8 +115,7 @@ room2=room2_3
 [1048a]
 descr=Spawns SCP-1048-A inside the room.
 room1=room2
-room2=room2_2
-room3=room2_3
+room2=room2_3
 
 [room2fan]
 descr=Activates the fan in the room.


### PR DESCRIPTION
Resolves issue #246.
- Remove room2_2 from list of rooms that the SCP-1048-A event can be applied to in the map maker, resolving the issue where applying this event to room2_2 causes the fan in the room to be manipulated erroneously; in the vanilla game, only the room named room2 receives the 1048a event, so it is likely that including room2_2 in this list was a mistake (although room2_3 can receive the event just fine)
- Fix incorrect name of event that allows SCP-372 to spawn, resolving the issue where SCP-372 wouldn't spawn in custom maps even if the event was applied to roompj correctly